### PR TITLE
converters within iterative structures (fixes #868)

### DIFF
--- a/xlwings/_xlmac.py
+++ b/xlwings/_xlmac.py
@@ -13,22 +13,17 @@ from appscript import k as kw, mactypes, its
 from appscript.reference import CommandError
 
 from .constants import ColorIndex
-from .utils import int_to_rgb, np_datetime_to_datetime, col_name, VersionNumber
+from .utils import int_to_rgb, col_name, VersionNumber
 from . import mac_dict, PY3, string_types
 
 try:
     import pandas as pd
 except ImportError:
     pd = None
-try:
-    import numpy as np
-except ImportError:
-    np = None
+
 
 # Time types
 time_types = (dt.date, dt.datetime)
-if np:
-    time_types = time_types + (np.datetime64,)
 
 
 class Apps(object):
@@ -1116,13 +1111,6 @@ def clean_value_data(data, datetime_builder, empty_as, number_builder):
 def prepare_xl_data_element(x):
     if x is None:
         return ""
-    elif np and isinstance(x, float) and np.isnan(x):
-        return ""
-    elif np and isinstance(x, np.datetime64):
-        # handle numpy.datetime64
-        return np_datetime_to_datetime(x).replace(tzinfo=None)
-    elif np and isinstance(x, np.number):
-        return float(x)
     elif pd and isinstance(x, pd.Timestamp):
         # This transformation seems to be only needed on Python 2.6 (?)
         return x.to_pydatetime().replace(tzinfo=None)

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -26,23 +26,17 @@ from comtypes import IUnknown
 from comtypes.automation import IDispatch
 
 from .constants import ColorIndex
-from .utils import rgb_to_int, int_to_rgb, get_duplicates, np_datetime_to_datetime, col_name
+from .utils import rgb_to_int, int_to_rgb, get_duplicates, col_name
 
 # Optional imports
 try:
     import pandas as pd
 except ImportError:
     pd = None
-try:
-    import numpy as np
-except ImportError:
-    np = None
 
 from . import PY3
 
 time_types = (dt.date, dt.datetime, pywintypes.TimeType)
-if np:
-    time_types = time_types + (np.datetime64,)
 
 
 N_COM_ATTEMPTS = 0      # 0 means try indefinitely
@@ -992,9 +986,6 @@ def _datetime_to_com_time(dt_time):
     # Convert date to datetime
     if pd and isinstance(dt_time, type(pd.NaT)):
         return None
-    if np:
-        if type(dt_time) is np.datetime64:
-            dt_time = np_datetime_to_datetime(dt_time)
 
     if type(dt_time) is dt.date:
         dt_time = dt.datetime(dt_time.year, dt_time.month, dt_time.day,
@@ -1023,11 +1014,7 @@ def _datetime_to_com_time(dt_time):
 def prepare_xl_data_element(x):
     if isinstance(x, time_types):
         return _datetime_to_com_time(x)
-    elif np and isinstance(x, np.number):
-        return float(x)
     elif x is None:
-        return ""
-    elif np and isinstance(x, float) and np.isnan(x):
         return ""
     else:
         return x

--- a/xlwings/conversion/framework.py
+++ b/xlwings/conversion/framework.py
@@ -179,8 +179,16 @@ class Converter(Accessor):
 
     @classmethod
     def read_value(cls, value, options):
-        return value
+        base_reader = cls.base_reader(options)
+        if isinstance(base_reader, Converter):
+            return cls.base_reader(options).read_value(value, options)
+        else:
+            return value
 
     @classmethod
     def write_value(cls, value, options):
-        return value
+        base_writer = cls.base_writer(options)
+        if isinstance(base_writer, Converter):
+            return cls.base_writer(options).write_value(value, options)
+        else:
+            return value

--- a/xlwings/conversion/framework.py
+++ b/xlwings/conversion/framework.py
@@ -69,6 +69,13 @@ class Pipeline(list):
 
 class Registry(OrderedDict):
 
+    def __contains__(self, cls):
+        try:
+            self.__getitem__(cls)
+            return True
+        except KeyError:
+            return False
+
     def __getitem__(self, cls):
         types = cls.mro() if hasattr(cls, 'mro') else [cls]
         for type_ in types:
@@ -81,6 +88,12 @@ class Registry(OrderedDict):
 
     def __setitem__(self, key, value):
         super(Registry, self).__setitem__(key, value)
+
+    def get(self, cls, default=None):
+        try:
+            return self.__getitem__(cls)
+        except KeyError:
+            return default
 
     def register(self, cls, accessor):
         self[cls] = accessor

--- a/xlwings/conversion/framework.py
+++ b/xlwings/conversion/framework.py
@@ -176,3 +176,11 @@ class Converter(Accessor):
             cls.base_writer(options)
             .prepend_stage(cls.ToValueStage(cls.write_value, options))
         )
+
+    @classmethod
+    def read_value(cls, value, options):
+        return value
+
+    @classmethod
+    def write_value(cls, value, options):
+        return value

--- a/xlwings/conversion/framework.py
+++ b/xlwings/conversion/framework.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collections import OrderedDict
 
 
 class ConversionContext(object):
@@ -66,28 +67,23 @@ class Pipeline(list):
             stage(*args, **kwargs)
 
 
-class Registry(object):
-    def __init__(self, dict_=None):
-        self._dict = dict_ or {}
+class Registry(OrderedDict):
 
     def __getitem__(self, cls):
         types = cls.mro() if hasattr(cls, 'mro') else [cls]
         for type_ in types:
             try:
-                return self._dict[type_]
+                return super(Registry, self).__getitem__(type_)
             except KeyError:
                 continue
         else:
             raise KeyError()
 
-    def register(self, cls, accessor):
-        self._dict[cls] = accessor
+    def __setitem__(self, key, value):
+        super(Registry, self).__setitem__(key, value)
 
-    def get(self, cls, default):
-        try:
-            return self[cls]
-        except KeyError:
-            return default
+    def register(self, cls, accessor):
+        self[cls] = accessor
 
 
 accessors = Registry()

--- a/xlwings/conversion/framework.py
+++ b/xlwings/conversion/framework.py
@@ -66,7 +66,30 @@ class Pipeline(list):
             stage(*args, **kwargs)
 
 
-accessors = {}
+class Registry(object):
+    def __init__(self, dict_=None):
+        self._dict = dict_ or {}
+
+    def __getitem__(self, cls):
+        for type_ in cls.mro():
+            try:
+                return self._dict[type_]
+            except KeyError:
+                continue
+        else:
+            raise KeyError()
+
+    def register(self, cls, accessor):
+        self._dict[cls] = accessor
+
+    def get(self, cls, default):
+        try:
+            return self[cls]
+        except KeyError:
+            return default
+
+
+accessors = Registry()
 
 
 class Accessor(object):
@@ -81,8 +104,8 @@ class Accessor(object):
 
     @classmethod
     def register(cls, *types):
-        for type in types:
-            accessors[type] = cls
+        for type_ in types:
+            accessors.register(type_, cls)
 
     @classmethod
     def router(cls, value, rng, options):

--- a/xlwings/conversion/framework.py
+++ b/xlwings/conversion/framework.py
@@ -71,7 +71,8 @@ class Registry(object):
         self._dict = dict_ or {}
 
     def __getitem__(self, cls):
-        for type_ in cls.mro():
+        types = cls.mro() if hasattr(cls, 'mro') else [cls]
+        for type_ in types:
             try:
                 return self._dict[type_]
             except KeyError:

--- a/xlwings/conversion/framework.py
+++ b/xlwings/conversion/framework.py
@@ -89,6 +89,10 @@ class Registry(OrderedDict):
     def __setitem__(self, key, value):
         super(Registry, self).__setitem__(key, value)
 
+    def all(self):
+        # return all types sorted by inheritance
+        return sorted(self.keys(), key=lambda x: len(x.mro()), reverse=True)
+
     def get(self, cls, default=None):
         try:
             return self.__getitem__(cls)

--- a/xlwings/conversion/numpy_conv.py
+++ b/xlwings/conversion/numpy_conv.py
@@ -14,6 +14,10 @@ if np:
         pd = None
 
     from . import Converter, Options
+    from ..utils import np_datetime_to_datetime
+
+    NAN = ""
+
 
     class NumpyArrayConverter(Converter):
 
@@ -42,3 +46,48 @@ if np:
 
 
     NumpyArrayConverter.register(np.array, np.ndarray)
+
+
+    class NumpyDateConverter(Converter):
+
+        write_types = np.datetime64
+
+        @classmethod
+        def write_value(cls, value, options):
+            return np_datetime_to_datetime(value)
+
+
+    NumpyDateConverter.register(np.datetime64)
+
+
+    class NumpyFloatConverter(Converter):
+        write_types = float
+
+        @classmethod
+        def write_value(cls, value, options):
+            if np.isnan(value):
+                return NAN
+            else:
+                return value
+
+
+    NumpyFloatConverter.register(float)
+
+
+    class NumpyNumberConverter(Converter):
+
+        base_type = float
+
+        @classmethod
+        def read_value(cls, value, options):
+            if value == NAN:
+                return np.NaN
+            else:
+                return value
+
+        @classmethod
+        def write_value(cls, value, options):
+            return super(NumpyNumberConverter, cls).write_value(float(value), options)
+
+
+    NumpyNumberConverter.register(np.number)

--- a/xlwings/conversion/standard.py
+++ b/xlwings/conversion/standard.py
@@ -214,6 +214,7 @@ class RawValueAccessor(Accessor):
             .prepend_stage(WriteValueToRangeStage(options, raw=True))
         )
 
+
 RawValueAccessor.register('raw')
 
 

--- a/xlwings/conversion/standard.py
+++ b/xlwings/conversion/standard.py
@@ -169,11 +169,16 @@ class ConvertDataFromReadStage(ConvertDataStage):
             return []
 
         # convert to list of types
-        if not isinstance(types, (list, tuple)):
+        if types == 'all':
+            types = self._sort_types_by_inheritance(accessors.keys())
+        elif not isinstance(types, (list, tuple)):
             types = [types]
 
         # get converters
         return (accessors[cls] for cls in types if cls in accessors and issubclass(accessors[cls], Converter))
+
+    def _sort_types_by_inheritance(self, types):
+        return sorted(types, key=lambda x: len(x.mro()), reverse=True)
 
 
 class ConvertDataForWriteStage(ConvertDataStage):

--- a/xlwings/conversion/standard.py
+++ b/xlwings/conversion/standard.py
@@ -160,7 +160,6 @@ class ConvertDataFromReadStage(ConvertDataStage):
     def _convert(self, converter, value):
         return converter.read_value(value, self.options)
 
-    @abstractmethod
     def _resolve_converters(self, value):
         # get options
         try:
@@ -192,7 +191,7 @@ class ConvertDataForWriteStage(ConvertDataStage):
         # NOTE: there is an asymmetry between the read and write stages because we know the type at write stage, so
         # we know what to convert to.
         converter = accessors.get(type(value), None)
-        return [converter] if issubclass(converter, Converter) else []
+        return [converter] if converter and issubclass(converter, Converter) else []
 
 
 class AdjustDimensionsStage(object):

--- a/xlwings/tests/test_conversion.py
+++ b/xlwings/tests/test_conversion.py
@@ -118,7 +118,7 @@ class TestConversionStage(TestBase):
     class EnumConverter(Converter):
         @classmethod
         def read_value(cls, value, options):
-            type_ = options['types']
+            type_ = options['convert']
             return type_(value)
 
         @classmethod
@@ -130,7 +130,7 @@ class TestConversionStage(TestBase):
     def test_enum(self):
         e = TestConversionStage.MyEnum.A
         self.wb1.sheets[0].range('A1').value = e
-        self.assertEqual(e, self.wb1.sheets[0].range('A1').options(types=TestConversionStage.MyEnum).value)
+        self.assertEqual(e, self.wb1.sheets[0].range('A1').options(convert=TestConversionStage.MyEnum).value)
 
     def test_list_of_enum(self):
         e = [TestConversionStage.MyEnum.A, TestConversionStage.MyEnum.B]

--- a/xlwings/tests/test_conversion.py
+++ b/xlwings/tests/test_conversion.py
@@ -118,7 +118,7 @@ class TestConversionStage(TestBase):
     class EnumConverter(Converter):
         @classmethod
         def read_value(cls, value, options):
-            type_ = options['of_type']
+            type_ = options['type']
             return type_(value)
 
         @classmethod
@@ -130,12 +130,12 @@ class TestConversionStage(TestBase):
     def test_enum(self):
         e = TestConversionStage.MyEnum.A
         self.wb1.sheets[0].range('A1').value = e
-        self.assertEqual(e, self.wb1.sheets[0].range('A1').options(of_type=TestConversionStage.MyEnum).value)
+        self.assertEqual(e, self.wb1.sheets[0].range('A1').options(type=TestConversionStage.MyEnum).value)
 
     def test_list_of_enum(self):
         e = [TestConversionStage.MyEnum.A, TestConversionStage.MyEnum.B]
         self.wb1.sheets[0].range('A27:B27').value = e
-        self.assertEqual(e, self.wb1.sheets[0].range('A27:B27').options(of_type=TestConversionStage.MyEnum).value)
+        self.assertEqual(e, self.wb1.sheets[0].range('A27:B27').options(type=TestConversionStage.MyEnum).value)
 
 
 @unittest.skipIf(np is None, 'numpy missing')

--- a/xlwings/tests/test_conversion.py
+++ b/xlwings/tests/test_conversion.py
@@ -118,7 +118,7 @@ class TestConversionStage(TestBase):
     class EnumConverter(Converter):
         @classmethod
         def read_value(cls, value, options):
-            type_ = options['type']
+            type_ = options['types']
             return type_(value)
 
         @classmethod
@@ -130,12 +130,12 @@ class TestConversionStage(TestBase):
     def test_enum(self):
         e = TestConversionStage.MyEnum.A
         self.wb1.sheets[0].range('A1').value = e
-        self.assertEqual(e, self.wb1.sheets[0].range('A1').options(type=TestConversionStage.MyEnum).value)
+        self.assertEqual(e, self.wb1.sheets[0].range('A1').options(types=TestConversionStage.MyEnum).value)
 
     def test_list_of_enum(self):
         e = [TestConversionStage.MyEnum.A, TestConversionStage.MyEnum.B]
         self.wb1.sheets[0].range('A27:B27').value = e
-        self.assertEqual(e, self.wb1.sheets[0].range('A27:B27').options(type=TestConversionStage.MyEnum).value)
+        self.assertEqual(e, self.wb1.sheets[0].range('A27:B27').options(types=TestConversionStage.MyEnum).value)
 
 
 @unittest.skipIf(np is None, 'numpy missing')


### PR DESCRIPTION
So that's the basic idea. I have also added the code for the other issue I flagged regarding conversion and inheritance.

It is very simple for now, but if you think the overall idea makes sense, there is a couple of things I could have a look at:
- allow multiple types to be tested against in the _conversion stages_, instead of only one type right now: `options(types=(enum, date))` would test against an enum and then a date if the first conversion fails. One could also pass `options(types='all')` so an object is tested against all types registered with accessors.
- move the conversion logic that currently resides inside the _clean data_ stages (for example the conversion to _numpy types, date, datetime, int_...) provided that they are consistent across Windows and Mac (that I have not checked).
- As mentioned in the initial issue I raised, it may make sense to distinguish the `Converters` for iterative structures like: _list, dict, dataframe_... that get converted into a range and the `Converters` for single item like _date, enum_... that get converted to a value at a later stage.
 