### PR TITLE
Bug Fix: conflict on how python and sqlite3 interpret the apostrophe

### DIFF
--- a/xlwings/ext/sql.py
+++ b/xlwings/ext/sql.py
@@ -47,6 +47,7 @@ def sql(query, *tables):
                     for row in rows
                 )
             )
+            stmt = stmt.replace("\\'", "''")
             c.execute(stmt)
 
     res = []


### PR DESCRIPTION
This is to fix a bug that shows up when the excel cell has both (") and (')

example: if cell contains the following text: X"Y'Z then sql.py will try to execute an INSERT statement with X"Y\'Z which is not understood by sqlite3 and causes an error. 

By replacing every \' instant by '' the statement error will be solved