### PR TITLE
Fixing bug of not being able to use vba=application and *args

### DIFF
--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -379,24 +379,15 @@ def generate_vba_wrapper(module_name, module, f):
                         vba.writeln('Application.Volatile')
 
                 if vararg != '':
-                    vba.writeln("ReDim argsArray(1 to UBound(" + vararg + ") - LBound(" + vararg + ") + " + str(n_args) + ")")
+                    vba.writeln("Dim argsArray() As Variant")
+                    non_varargs = [arg['vba'] or arg['name'] for arg in xlfunc['args'] if not arg['vararg']]
+                    vba.writeln(f"argsArray = Array({', '.join(non_varargs)})")
 
-                j = 1
-                for arg in xlfunc['args']:
-                    argname = arg['name']
-                    if arg['vararg']:
-                        vba.writeln("For k = LBound(" + vararg + ") To UBound(" + vararg + ")")
-                        argname = vararg + "(k)"
+                    vba.writeln("ReDim Preserve argsArray(0 to UBound(" + vararg + ") - LBound(" + vararg + ") + " + str(len(non_varargs)) + ")")
+                    vba.writeln("For k = LBound(" + vararg + ") To UBound(" + vararg + ")")
+                    vba.writeln("argsArray(" + str(len(non_varargs)) + " + k - LBound(" + vararg + ")) = " + argname + "(k)")
+                    vba.writeln("Next k")
 
-                    if arg['vararg']:
-                        vba.writeln("argsArray(" + str(j) + " + k - LBound(" + vararg + ")) = " + argname)
-                        vba.writeln("Next k")
-                    else:
-                        if vararg != "":
-                            vba.writeln("argsArray(" + str(j) + ") = " + argname)
-                            j += 1
-
-                if vararg != '':
                     args_vba = 'argsArray'
                 else:
                     args_vba = 'Array(' + ', '.join(arg['vba'] or arg['name'] for arg in xlfunc['args']) + ')'


### PR DESCRIPTION
Bug: varargs does not work in combination with a "vba=" statement, for example to get the "Application" datastructure from excel.

Example:

@xw.arg('xl_app', vba='Application')
def vararg_func(xl_app, name, *args):
    pass

Fix:
Changed the Python code that generates the vba function wrappers.
Just setting all "argsArray" elements separately did not work for datastructures like "Application".
Workaround: Build an Array(...) first, then Redim into desired size and fill with varargs.

Convention: varargs "*args" must be last in enumeration of arguments in Python!