### PR TITLE
does not match release dll files

### DIFF
--- a/xlwings/__init__.py
+++ b/xlwings/__init__.py
@@ -3,7 +3,7 @@ from functools import wraps
 import sys
 
 
-__version__ = 'dev'
+__version__ = '0.15.8'
 
 # Python 2 vs 3
 PY3 = sys.version_info[0] == 3


### PR DESCRIPTION
VBA error occurs despite repeated clean installs in conda. Replace "dev" with actual version number should resolve dll name mismatch.