### PR TITLE
Implement custom exceptions for caller errors

### DIFF
--- a/xlwings/__init__.py
+++ b/xlwings/__init__.py
@@ -45,10 +45,6 @@ else:
 
 time_types = xlplatform.time_types
 
-# Errors
-class ShapeAlreadyExists(Exception):
-    pass
-
 # API
 from .main import App, Book, Range, Chart, Sheet, Picture, Shape, Name, view, RangeRows, RangeColumns
 from .main import apps, books, sheets

--- a/xlwings/exceptions.py
+++ b/xlwings/exceptions.py
@@ -1,0 +1,18 @@
+class XlwingsError(Exception):
+    """Base exception for all custom xlwings errors."""
+    pass
+
+
+class ExcelCallError(XlwingsError):
+    """Exception for errors during calling of excel app from python."""
+    pass
+
+
+class PythonCallError(XlwingsError):
+    """Exception for errors during calling of python from excel app."""
+    pass
+
+
+class ShapeAlreadyExists(XlwingsError):
+    """Exception for errors regarding duplicate excel shapes."""
+    pass

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -15,9 +15,8 @@ import re
 import numbers
 import inspect
 
-from . import xlplatform, string_types, ShapeAlreadyExists, PY3
+from . import exceptions, PY3, string_types, utils, xlplatform
 from .utils import VersionNumber
-from . import utils
 
 # Optional imports
 try:
@@ -267,7 +266,9 @@ class App(object):
         # Win Excel >= 2013 fails if visible=False...we may somehow not be using the correct HWND
         self.impl.activate(steal_focus)
         if self != apps.active:
-            raise Exception('Could not activate App! Try to instantiate the App with visible=True.')
+            raise exceptions.ExcelCallError(
+                'Could not activate App! Try to instantiate the App with visible=True.'
+            )
 
     @property
     def visible(self):
@@ -567,8 +568,10 @@ class Book(object):
             # Called via OPTIMIZED_CONNECTION = True
             return cls(impl=xlplatform.Book(xlplatform.BOOK_CALLER))
         else:
-            raise Exception('Book.caller() must not be called directly. Call through Excel or set a mock caller '
-                            'first with Book.set_mock_caller().')
+            raise exceptions.PythonCallError(
+                'Book.caller() must not be called directly. Call through Excel or set a mock '
+                'caller first with Book.set_mock_caller().'
+            )
 
     def set_mock_caller(self):
         """
@@ -2280,7 +2283,7 @@ class Picture(object):
             if value == self.name:
                 return
             else:
-                raise ShapeAlreadyExists()
+                raise exceptions.ShapeAlreadyExists
 
         self.impl.name = value
 

--- a/xlwings/tests/test_shape.py
+++ b/xlwings/tests/test_shape.py
@@ -124,7 +124,7 @@ class TestPicture(TestBase):
         self.assertFalse('pic1' in self.wb1.sheets[0].pictures)
 
     def test_duplicate(self):
-        with self.assertRaises(xw.ShapeAlreadyExists):
+        with self.assertRaises(xw.exceptions.ShapeAlreadyExists):
             filename = os.path.join(this_dir, 'sample_picture.png')
             pic1 = self.wb1.sheets[0].pictures.add(filename, name='pic1')
             pic2 = self.wb1.sheets[0].pictures.add(filename, name='pic1')


### PR DESCRIPTION
Errors during during calls between python and an excel app would raise a
generic `Exception` error. Custom exceptions are implemented here
instead in order to enable users to perform more robust error catching.

A dedicated `exceptions` module and a base exception class are
introduced in order to facilitate implementation of further custom
exception classes in the future. The code organization is based on the
guidelines from Julien Danjou's "The definitive guide to Python
exceptions" (https://julien.danjou.info/python-exceptions-guide/)

Closes: #322
See also: #324, #859