### PR TITLE
Add support for path-like objects in API

### DIFF
--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -464,7 +464,7 @@ class Book(object):
 
     Parameters
     ----------
-    fullname : str, default None
+    fullname : str or path-like object, default None
         Full path or name (incl. xlsx, xlsm etc.) of existing workbook or name of an unsaved workbook. Without a full
         path, it looks for the file in the current working directory.
 
@@ -473,6 +473,7 @@ class Book(object):
     def __init__(self, fullname=None, impl=None):
         if not impl:
             if fullname:
+                fullname = utils.fspath(fullname)
                 fullname = fullname.lower()
 
                 candidates = []
@@ -689,7 +690,7 @@ class Book(object):
 
         Arguments
         ---------
-        path : str, default None
+        path : str or path-like object, default None
             Full path to the workbook
         Example
         -------
@@ -701,6 +702,8 @@ class Book(object):
 
         .. versionadded:: 0.3.1
         """
+        if path:
+            path = utils.fspath(path)
         return self.impl.save(path)
 
     @property
@@ -2367,7 +2370,7 @@ class Picture(object):
         Arguments
         ---------
 
-        image : str or matplotlib.figure.Figure
+        image : str or path-like object or matplotlib.figure.Figure
             Either a filepath or a Matplotlib figure object.
 
 
@@ -2412,7 +2415,7 @@ class Pictures(Collection):
         Arguments
         ---------
 
-        image : str or matplotlib.figure.Figure
+        image : str or path-like object or matplotlib.figure.Figure
             Either a filepath or a Matplotlib figure object.
 
         left : float, default 0
@@ -2756,7 +2759,7 @@ class Books(Collection):
 
         Parameters
         ----------
-        fullname : str
+        fullname : str or path-like object
             filename or fully qualified filename, e.g. ``r'C:\\path\\to\\file.xlsx'`` or ``'file.xlsm'``. Without a full
             path, it looks for the file in the current working directory.
 
@@ -2764,7 +2767,8 @@ class Books(Collection):
         -------
         Book : Book that has been opened.
 
-        """       
+        """
+        fullname = utils.fspath(fullname)
         if not os.path.exists(fullname):
             if PY3:
                 raise FileNotFoundError("No such file: '%s'" % fullname)

--- a/xlwings/tests/test_shape.py
+++ b/xlwings/tests/test_shape.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import os
+import sys
 import unittest
 
 import xlwings as xw
@@ -17,10 +18,24 @@ try:
 except ImportError:
     PIL = None
 
+if sys.version_info[0] >= 3 and sys.version_info[1] >= 6:
+    import pathlib
+else:
+    pathlib = None
 
 class TestShape(TestBase):
     def test_name(self):
         filename = os.path.join(this_dir, 'sample_picture.png')
+        self.wb1.sheets[0].pictures.add(filename, name='pic1')
+
+        sh = self.wb1.sheets[0].shapes[0]
+        self.assertEqual(sh.name, 'pic1')
+        sh.name = "yoyoyo"
+        self.assertEqual(sh.name, 'yoyoyo')
+
+    @unittest.skipIf(pathlib is None, 'pathlib unavailable')
+    def test_name_pathlib(self):
+        filename = pathlib.Path(this_dir) / 'sample_picture.png'
         self.wb1.sheets[0].pictures.add(filename, name='pic1')
 
         sh = self.wb1.sheets[0].shapes[0]
@@ -133,6 +148,13 @@ class TestPicture(TestBase):
         filename = os.path.join(this_dir, 'sample_picture.png')
         pic1 = self.wb1.sheets[0].pictures.add(filename, name='pic1')
         pic1.update(filename)
+
+    @unittest.skipIf(pathlib is None, 'pathlib unavailable')
+    def test_picture_update_pathlib(self):
+        filename = pathlib.Path(this_dir) / 'sample_picture.png'
+        pic1 = self.wb1.sheets[0].pictures.add(filename, name='pic1')
+        pic1.update(filename)
+
 
     def test_picture_auto_update(self):
         filename = os.path.join(this_dir, 'sample_picture.png')

--- a/xlwings/tests/test_shape.py
+++ b/xlwings/tests/test_shape.py
@@ -155,7 +155,6 @@ class TestPicture(TestBase):
         pic1 = self.wb1.sheets[0].pictures.add(filename, name='pic1')
         pic1.update(filename)
 
-
     def test_picture_auto_update(self):
         filename = os.path.join(this_dir, 'sample_picture.png')
         pic1 = self.wb1.sheets[0].pictures.add(filename, name='pic1', update=True)

--- a/xlwings/utils.py
+++ b/xlwings/utils.py
@@ -188,6 +188,7 @@ class VersionNumber(object):
 
 def process_image(image, width, height):
 
+    image = fspath(image)
     if isinstance(image, string_types):
         return image, width, height
     elif mpl and isinstance(image, mpl.figure.Figure):
@@ -207,3 +208,16 @@ def process_image(image, width, height):
         return filename, width, height
     else:
         raise TypeError("Don't know what to do with that image object")
+
+
+def fspath(path):
+    """Convert path-like object to string.
+
+    On python <= 3.5 the input argument is always returned unchanged (no support for path-like
+    objects available).
+
+    """
+    if hasattr(os, 'PathLike') and isinstance(path, os.PathLike):
+        return os.fspath(path)
+    else:
+        return path


### PR DESCRIPTION
This pull request adds support for [path-like objects](https://www.python.org/dev/peps/pep-0519/) (available in python 3.6 and higher) to API input arguments. It should now be possible for users to provide any object that is an instance of [`os.PathLike`](https://docs.python.org/3/library/os.html#os.PathLike) (which includes [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html) objects) as path argument.

The changes made basically amount to ensuring that any path-like object is converted to a string object at the earliest opportunity.

Included as well are some new unit tests with `pathlib.Path` objects.

Closes: #1124