### PR TITLE
Use formula cache to prevent disappearing legacy dynamic array

### DIFF
--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -216,9 +216,6 @@ class DelayedResizeDynamicArrayFormula(object):
         if self.needs_clearing:
             self.caller.ClearContents()
         self.target_range.api.FormulaArray = formula
-        ### TEMP
-        print(f'current cache at end of DelayedResizeDynamicArrayFormula is {cache}')
-        ### END TEMP
 
 
 def get_udf_module(module_name):
@@ -404,10 +401,6 @@ def call_udf(module_name, func_name, args, this_workbook=None, caller=None):
 
         del_formula_cache = partial(safe_delete_from_cache, cache, formula_cache_key, 'formula_cache_key')
         add_idle_task(del_formula_cache)
-
-    ### TEMP
-    print(f'current cache at end of call_udf is {cache}')
-    ### END TEMP
 
     return xl_result
 

--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -4,11 +4,9 @@ import sys
 import re
 import tempfile
 import inspect
-import logging
 from functools import partial
 from importlib import import_module
 from threading import Thread
-import uuid
 
 from win32com.client import Dispatch, CDispatch
 import pywintypes
@@ -16,7 +14,6 @@ import pywintypes
 from . import conversion, xlplatform, Range, apps, PY3
 from .utils import VBAWriter
 
-logger = logging.getLogger(__name__)
 
 cache = {}
 

--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -256,6 +256,14 @@ def get_cache_key(func, args, caller):
             xw_caller.sheet.book.name + xw_caller.sheet.name + xw_caller.address.split(':')[0])
 
 
+def get_formula_cache_key(func, caller):
+    """only use this if function is called from cells, not VBA, and only if is a dynamic function"""
+    xw_caller = Range(impl=xlplatform.Range(xl=caller))
+    # arguments are not needed for function cache
+    return ('formula_array' + func.__name__ + str(xw_caller.sheet.book.app.pid) +
+            xw_caller.sheet.book.name + xw_caller.sheet.name + xw_caller.address.split(':')[0])
+
+
 def safe_delete_from_cache(cache, key, task_key_attr='formula_cache_key'):
     """
     Deleting formula cache immediately or as a regular idle task causes it to be deleted before
@@ -357,7 +365,7 @@ def call_udf(module_name, func_name, args, this_workbook=None, caller=None):
             return [["#N/A waiting..." * xw_caller.columns.count] * xw_caller.rows.count]
     else:
         if is_dynamic_array:
-            formula_cache_key = 'formula_array' + get_cache_key(func, args, caller)
+            formula_cache_key = get_formula_cache_key(func, caller)
             try:
                 # Can't get array_formula during dynamic array resizing
                 formula_array = caller.FormulaArray


### PR DESCRIPTION
This PR fixes #1164 in my testing.

It seems that the issue was that the resize operation is getting called multiple times, and in the test workbook attached in #1164, `DelayedResizeDynamicArrayFormula` would be able to get the formula on the first resize operation, but thereafter it was getting the formula as `None` when pulling from `self.caller.FormulaArray`.

I fixed this by implementing the formula caching approach from `xlwings-1010-improve-async`, though with a slight modification and a different spot. It is still in `call_udf` but now under the `if is_dynamic_array` block. Then `DelayedResizeDynamicArrayFormula` retrieves from cache if it gets `None` for the formula. So now we have function cache in addition to the existing result cache.

As described in `xlwings-1010-improve-async`, there is sometimes a `com_error` while getting the formula from caller during dynamic array resizing. I added error handling for if somehow we hit the error before the resizing, as then there would be no formula in the cache.

Then I went to remove the formula from the cache. I tried three approaches for this, settling on the third. The first was simply deleting the formula cache where we are deleting the result cache, right before the end of `call_udf`. Then I tried creating a function which does this and passing it to `add_idle_task` in the same spot. Both of these approaches still reach the exception I added for not being able to access `caller.FormulaArray` and also not having the formula in the cache (it is clearing the cache too early). 

The third approach for removing the formula cache, and the one currently used, builds on top of the idle task approach, but the function to delete also queries the idle queue to check if any tasks are still using the cache key. If any are, then it adds itself to the end of the queue for later deletion. If not, then it will move forward with deletion. 

I noticed in my debugging of the cache that the result cache was already not being handled properly, the result cache keys (which I didn't touch) were building up for various different results throughout the multiple calculations of the dynamic array. So I tried generalizing this safe cache delete and applying it to the existing result cache as well. For some reason, this caused `xlwings` to hang, so I reversed this change, now applying only to the formula cache. So now the state of the cache is as it was before this PR, cache keys build up for result cache, but there are no leftover formula cache keys (before these didn't exist).

I am open to suggestions to remove the leftover result cache as well, though this is going beyond the scope of fixing #1164 

I'm not sure if there are any side effects of this approach, or if I have covered all the cases. But it works in my testing and passes `nosetests`. I would be happy to make additional changes if necessary.