### PR TITLE
make refers_to_range deal with quotes

### DIFF
--- a/xlwings/_xlmac.py
+++ b/xlwings/_xlmac.py
@@ -1106,7 +1106,7 @@ class Name:
     def refers_to_range(self):
         book = self.parent if isinstance(self.parent, Book) else self.parent.book
         external_address = self.xl.reference_range.get_address(external=True)
-        match = re.search(r"\](.*)!(.*)", external_address)
+        match = re.search(r"\](.*)'!(.*)", external_address)
         return Range(Sheet(book, match.group(1)), match.group(2))
 
 


### PR DESCRIPTION
The address produced with external=True includes quotes around the workbook/sheet pair in the form `'[book.xlsm]sheet'!$A$1`. The current regex results in sheet name that includes the trailing quote, which results in reference to a non-existent sheet.

This patch excludes the trailing quote from the group that is expected to match the sheet name.