### PR TITLE
Add support to create xlsx with wps office application

### DIFF
--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -292,7 +292,13 @@ class App:
             warn('spec is ignored on Windows.')
         if xl is None:
             # new instance
-            self._xl = COMRetryObjectWrapper(DispatchEx('Excel.Application'))
+
+            try:
+                self._xl = COMRetryObjectWrapper(DispatchEx('Excel.Application'))
+            except pywintypes.com_error:
+                # for system with WPS Office installed
+                self._xl = COMRetryObjectWrapper(DispatchEx('KET.Application'))
+
             if add_book:
                 self._xl.Workbooks.Add()
             self._hwnd = None


### PR DESCRIPTION
When I use xlwings to process xlsx files. I got an error because I did not installed Microsoft Office Excel.

I am an WPS user. It is a softwae like Excel.I have made a modification in source code, and looks like it works fine on my tasks. Maybe you could have a look.
