### PR TITLE
Fix COMRetryObjectWrapper

### DIFF
--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -22,7 +22,7 @@ import types
 from ctypes import oledll, PyDLL, py_object, byref, POINTER, windll
 
 import pythoncom
-from win32com.client import Dispatch, CDispatch, DispatchEx
+from win32com.client import Dispatch, CoClassBaseClass, DispatchEx, DispatchBaseClass
 import win32timezone
 import win32gui
 import win32process
@@ -64,10 +64,9 @@ class COMRetryMethodWrapper:
         while True:
             try:
                 v = self.__method(*args, **kwargs)
-                t = type(v)
-                if t is CDispatch:
+                if isinstance(v, (CoClassBaseClass, DispatchBaseClass)):
                     return COMRetryObjectWrapper(v)
-                elif t is types.MethodType:
+                elif type(v) is types.MethodType:
                     return COMRetryMethodWrapper(v)
                 else:
                     return v
@@ -118,10 +117,9 @@ class COMRetryObjectWrapper:
         while True:
             try:
                 v = getattr(self._inner, item)
-                t = type(v)
-                if t is CDispatch:
+                if isinstance(v, (CoClassBaseClass, DispatchBaseClass)):
                     return COMRetryObjectWrapper(v)
-                elif t is types.MethodType:
+                elif type(v) is types.MethodType:
                     return COMRetryMethodWrapper(v)
                 else:
                     return v
@@ -153,10 +151,9 @@ class COMRetryObjectWrapper:
         for i in range(N_COM_ATTEMPTS + 1):
             try:
                 v = self._inner(*args, **kwargs)
-                t = type(v)
-                if t is CDispatch:
+                if isinstance(v, (CoClassBaseClass, DispatchBaseClass)):
                     return COMRetryObjectWrapper(v)
-                elif t is types.MethodType:
+                elif type(v) is types.MethodType:
                     return COMRetryMethodWrapper(v)
                 else:
                     return v
@@ -175,8 +172,7 @@ class COMRetryObjectWrapper:
 
     def __iter__(self):
         for v in self._inner:
-            t = type(v)
-            if t is CDispatch:
+            if isinstance(v, (CoClassBaseClass, DispatchBaseClass)):
                 yield COMRetryObjectWrapper(v)
             else:
                 yield v


### PR DESCRIPTION
Currently it doesn't work with pywin32 COM generated dynamic dispatch, as the generated classes are subclasses of `CoClassBaseClass` and the code just tests for `is CDispatch` (generic dynamic dispatch). I've widened the check to DispatchBaseClass to cover this too.