### PR TITLE
introduced "caller" argument for UDFs

### DIFF
--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -425,6 +425,13 @@ def call_udf(module_name, func_name, args, this_workbook=None, caller=None):
     is_dynamic_array = ret_info['options'].get('expand')
     xw_caller = Range(impl=xlplatform.Range(xl=caller))
 
+    # If there is the 'reserved' argument "caller", assign the caller object
+    for info in args_info:
+        if info['name'] == 'caller':
+            args = list(args)
+            args[info['pos']] = xw_caller
+            args = tuple(args)
+
     writing = func_info.get('writing', None)
     if writing and writing == xw_caller.address:
         return func_info['rval']
@@ -537,6 +544,8 @@ def generate_vba_wrapper(module_name, module, f):
             vararg = ''
             n_args = len(xlfunc['args'])
             for arg in xlfunc['args']:
+                if arg['name'] == 'caller':
+                    arg['vba'] = 'Nothing'  # will be replaced with caller under call_udf
                 if not arg['vba']:
                     argname = arg['name']
                     if not first:


### PR DESCRIPTION
So far, the easiest way to get to the caller object in the form of an xlwings range object was along these lines:

```python
import xlwings as xw
from xlwings import xlplatform

@xw.func
@xw.arg('xl', vba='Application')
def get_caller_address(xl):
    return xw.Range(impl=xlplatform.Range(xl=xl.Caller)).address
```

This can now be done by introducing the `caller` argument:

```python
import xlwings as xw

@xw.func
def get_caller_address(caller):
    return caller.address
```

On the Excel side, argument with the name `caller` will be hidden, so this function will have 0 arguments. That's a breaking change, but should have minimal impact as I don't expect many users to have an existing argument called `caller`. In any case, it's easily fixable by renaming existing arguments into something else.