### PR TITLE
Added app.suspend() context manager

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -77,6 +77,21 @@ class TestApp(TestBase):
         self.app1.display_alerts = True
         self.assertTrue(self.app1.display_alerts)
 
+    def test_enable_events(self):
+        self.app1.enable_events = False
+        self.assertEqual(self.app1.enable_events, False)
+
+        self.app1.enable_events = True
+        self.assertTrue(self.app1.enable_events)
+
+    @unittest.skipIf(sys.platform.startswith('darwin'), 'app.interactive is not supported on macOS')
+    def test_interactive(self):
+        self.app1.interactive = False
+        self.assertEqual(self.app1.interactive, False)
+
+        self.app1.interactive = True
+        self.assertTrue(self.app1.interactive)
+
     def test_calculation_calculate(self):
         sht = self.wb1.sheets[0]
         sht.range('A1').value = 2

--- a/tests/test_app_suspend.py
+++ b/tests/test_app_suspend.py
@@ -1,0 +1,82 @@
+import sys
+from pathlib import Path
+
+import pytest
+import xlwings as xw
+
+this_dir = Path(__file__).resolve().parent
+
+
+@pytest.fixture(scope="module")
+def app():
+    with xw.App(visible=False) as app:
+        yield app
+
+
+def test_suspend_empty(app):
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True))
+    with app.suspend():
+        assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+                ('automatic', True, True, True))
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True))
+
+
+def test_suspend_screen(app):
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True))
+    with app.suspend('screen'):
+        assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating) ==
+                ('automatic', True, True, False))
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True))
+
+
+def test_suspend_events(app):
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True))
+    with app.suspend('events'):
+        assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating) ==
+                ('automatic', False, True, True))
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True))
+
+
+def test_suspend_alerts(app):
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True))
+    with app.suspend('alerts'):
+        assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating) ==
+                ('automatic', True, False, True))
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True))
+
+
+def test_suspend_calculation(app):
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True))
+    with app.suspend('calculation'):
+        assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating) ==
+                ('manual', True, True, True))
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True))
+
+
+@pytest.mark.skipif(sys.platform.startswith('darwin'), reason='app.interactive is not supported on macOS')
+def test_suspend_interactive(app):
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating, app.interactive),
+            ('automatic', True, True, True, True))
+    with app.suspend('interactive'):
+        assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating, app.interactive) ==
+                ('automatic', True, True, True, False))
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True, True))
+
+
+def test_suspend_multiple(app):
+    with app.suspend('screen', 'events'):
+        assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating) ==
+                ('automatic', False, True, False))
+    assert ((app.calculation, app.enable_events, app.display_alerts, app.screen_updating),
+            ('automatic', True, True, True))

--- a/xlwings/_xlmac.py
+++ b/xlwings/_xlmac.py
@@ -5,6 +5,7 @@ import subprocess
 import struct
 import shutil
 import atexit
+import warnings
 
 import psutil
 import aem
@@ -134,6 +135,24 @@ class App:
     @display_alerts.setter
     def display_alerts(self, value):
         self.xl.display_alerts.set(value)
+
+    @property
+    def enable_events(self):
+        return self.xl.enable_events.get()
+
+    @enable_events.setter
+    def enable_events(self, value):
+        self.xl.enable_events.set(value)
+
+    @property
+    def interactive(self):
+        warnings.warn("Getting or setting 'app.interactive' isn't supported on macOS.")
+        return
+
+    @interactive.setter
+    def interactive(self, value):
+        warnings.warn("Getting or setting 'app.interactive' isn't supported on macOS.")
+        pass
 
     @property
     def startup_path(self):
@@ -329,6 +348,7 @@ class Book:
         self.app.display_alerts = False
         self.xl.save(in_=hfs_path, as_=kw.PDF_file_format)
         self.app.display_alerts = display_alerts
+
 
 class Sheets:
 

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -389,6 +389,22 @@ class App:
         self.xl.DisplayAlerts = value
 
     @property
+    def enable_events(self):
+        return self.xl.EnableEvents
+
+    @enable_events.setter
+    def enable_events(self, value):
+        self.xl.EnableEvents = value
+
+    @property
+    def interactive(self):
+        return self.xl.Interactive
+
+    @interactive.setter
+    def interactive(self, value):
+        self.xl.Interactive = value
+
+    @property
     def startup_path(self):
         return self.xl.StartupPath
 


### PR DESCRIPTION
Closes issue #254 and replaces PR #260.

6 years later, the time has finally come for your PR, @sdementen 😆  Some explanations:

* I changed `freeze` to `suspend` because when a program `freezes`, it's generally a bad thing (as someone mentioned on the issue). `suspend` is used by Microsoft in OfficeScript: https://docs.microsoft.com/en-us/office/dev/add-ins/excel/performance#suspend-screen-updating

* I replaced the kwargs/boolean approach with positional string args as setting a boolean value opposite to it's effect is just too confusing for me (technically, it would be correct, no doubt):

  ```python
  with app.suspend(interactive=True):
      # This sets app.interactive = False
  ```

  Instead, this now reads:

  ```python
  with app.suspend('interactive'):
      # This sets app.interactive = False
  ```

~* The default suspends `screen`, `alerts`, `calculation` and `events`. Not sure if that's the best selection, but I definitely want to leave out `interactive` unless explicitly requested.~


Let me know what you think @sdementen and maybe @wkschwartz, you want to chime in as you liked the original PR back then.