### PR TITLE
PDF export for charts and ranges and PDF export quality

### DIFF
--- a/xlwings/_xlmac.py
+++ b/xlwings/_xlmac.py
@@ -348,7 +348,8 @@ class Book:
     def activate(self):
         self.xl.activate_object()
 
-    def to_pdf(self, path):
+    def to_pdf(self, path, quality=None):
+        # quality parameter for compatibility
         hfs_path = posix_to_hfs_path(path)
         display_alerts = self.app.display_alerts
         self.app.display_alerts = False

--- a/xlwings/_xlmac.py
+++ b/xlwings/_xlmac.py
@@ -12,7 +12,7 @@ import appscript
 from appscript import k as kw, mactypes, its
 from appscript.reference import CommandError
 
-from .constants import ColorIndex
+from .constants import ColorIndex, FixedFormatQuality
 from .utils import int_to_rgb, np_datetime_to_datetime, col_name, VersionNumber
 from . import mac_dict
 import xlwings
@@ -919,6 +919,9 @@ class Range:
         im = ImageGrab.grabclipboard()
         im.save(path)
 
+    def to_pdf(self, path, quality=FixedFormatQuality.xlQualityStandard):
+        raise xlwings.XlwingsError("Range.to_pdf() isn't supported on macOS.")
+      
 
 class Shape:
 
@@ -1438,6 +1441,9 @@ class Chart:
         # self.xl_obj.save_as_picture(file_name=posix_to_hfs_path('...'),
         #                             picture_type=kw.save_as_PNG_file)
 
+    def to_pdf(self, path, quality=FixedFormatQuality.xlQualityStandard):
+        raise xlwings.XlwingsError("Chart.to_pdf() isn't supported on macOS.")
+      
 
 class Charts(Collection):
 

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -1168,6 +1168,15 @@ class Range:
                 if retry == max_retries - 1:
                     raise
 
+    def to_pdf(self, path, quality=FixedFormatQuality.xlQualityStandard):
+        self.xl.Select()
+        self.xl.ExportAsFixedFormat(Type=FixedFormatType.xlTypePDF,
+                                    Filename=path,
+                                    Quality=quality,
+                                    IncludeDocProperties=True,
+                                    IgnorePrintAreas=False,
+                                    OpenAfterPublish=False)
+
 
 def clean_value_data(data, datetime_builder, empty_as, number_builder):
     if number_builder is not None:
@@ -1829,6 +1838,14 @@ class Chart:
     def to_png(self, path):
         self.xl.Export(path)
 
+    def to_pdf(self, path, quality=FixedFormatQuality.xlQualityStandard):
+        self.xl_obj.Select()
+        self.xl.ExportAsFixedFormat(Type=FixedFormatType.xlTypePDF,
+                                    Filename=path,
+                                    Quality=quality,
+                                    IncludeDocProperties=True,
+                                    IgnorePrintAreas=False,
+                                    OpenAfterPublish=False)
 
 class Charts(Collection):
 

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -593,10 +593,10 @@ class Book:
     def activate(self):
         self.xl.Activate()
 
-    def to_pdf(self, path):
+    def to_pdf(self, path, quality=FixedFormatQuality.xlQualityStandard):
         self.xl.ExportAsFixedFormat(Type=FixedFormatType.xlTypePDF,
                                     Filename=path,
-                                    Quality=FixedFormatQuality.xlQualityStandard,
+                                    Quality=quality,
                                     IncludeDocProperties=True,
                                     IgnorePrintAreas=False,
                                     OpenAfterPublish=False)

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from contextlib import contextmanager
 
 from . import xlplatform, ShapeAlreadyExists, utils, XlwingsError
+from .constants import FixedFormatQuality
+
 import xlwings
 
 # Optional imports
@@ -913,7 +915,7 @@ class Book:
         """
         return Range(impl=self.app.selection.impl) if self.app.selection else None
 
-    def to_pdf(self, path=None, include=None, exclude=None, layout=None, exclude_start_string='#', show=False):
+    def to_pdf(self, path=None, include=None, exclude=None, layout=None, exclude_start_string='#', show=False, quality=FixedFormatQuality.xlQualityStandard):
         """
         Exports the whole Excel workbook or a subset of the sheets to a PDF file.
         If you want to print hidden sheets, you will need to list them explicitely under ``include``.
@@ -996,7 +998,7 @@ class Book:
                 for sheet in self.sheets:
                     if (sheet.name in exclude) or (sheet.index in exclude) or (sheet.index in exclude_by_name):
                         sheet.visible = False
-            self.impl.to_pdf(os.path.realpath(report_path))
+            self.impl.to_pdf(os.path.realpath(report_path), quality=quality)
         except Exception:
             raise
         finally:
@@ -1167,7 +1169,7 @@ class Sheet:
         """
         return self.impl.delete()
 
-    def to_pdf(self, path=None, layout=None, show=False):
+    def to_pdf(self, path=None, layout=None, show=False, quality=FixedFormatQuality.xlQualityStandard):
         """
         Exports the sheet to a PDF file.
 
@@ -1204,7 +1206,7 @@ class Sheet:
         .. versionadded:: 0.22.3
         """
         self.book.to_pdf(self.name + '.pdf' if path is None else path,
-                         include=self.index, layout=layout, show=show)
+                         include=self.index, layout=layout, show=show, quality=quality)
 
     def copy(self, before=None, after=None, name=None):
         """
@@ -2407,7 +2409,7 @@ class Range:
                 path = str(Path.cwd() / default_name) + '.png'
         self.impl.to_png(path)
 
-    def to_pdf(self, path=None):
+    def to_pdf(self, path=None, quality=FixedFormatQuality.xlQualityStandard):
         """
         Exports the range as PDF.
 
@@ -2427,7 +2429,7 @@ class Range:
                 path = os.path.join(directory, self.address + '.pdf')
             else:
                 path = str(Path.cwd() / self.address) + '.pdf'
-        self.impl.to_pdf(path)
+        self.impl.to_pdf(path, quality)
 
 # These have to be after definition of Range to resolve circular reference
 from . import conversion
@@ -3406,7 +3408,7 @@ class Chart:
                 path = str(Path.cwd() / self.name) + '.png'
         self.impl.to_png(path)
 
-    def to_pdf(self, path=None):
+    def to_pdf(self, path=None, quality=FixedFormatQuality.xlQualityStandard):
         """
         Exports the chart as PDF.
 
@@ -3426,7 +3428,7 @@ class Chart:
                 path = os.path.join(directory, self.name + '.pdf')
             else:
                 path = str(Path.cwd() / self.name) + '.pdf'
-        self.impl.to_pdf(path)
+        self.impl.to_pdf(path, quality=quality)
 
     def __repr__(self):
         return "<Chart '{0}' in {1}>".format(

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -2407,6 +2407,27 @@ class Range:
                 path = str(Path.cwd() / default_name) + '.png'
         self.impl.to_png(path)
 
+    def to_pdf(self, path=None):
+        """
+        Exports the range as PDF.
+
+        Parameters
+        ----------
+
+        path : str or path-like, default None
+            Path where you want to store the pdf. Defaults to the address of the range in the same
+            directory as the Excel file if the Excel file is stored and to the current working directory otherwise.
+
+        """
+        path = utils.fspath(path)
+        if path is None:
+            # fullname won't work if file is stored on OneDrive
+            directory, _ = os.path.split(self.sheet.book.fullname)
+            if directory:
+                path = os.path.join(directory, self.address + '.pdf')
+            else:
+                path = str(Path.cwd() / self.address) + '.pdf'
+        self.impl.to_pdf(path)
 
 # These have to be after definition of Range to resolve circular reference
 from . import conversion
@@ -3384,6 +3405,28 @@ class Chart:
             else:
                 path = str(Path.cwd() / self.name) + '.png'
         self.impl.to_png(path)
+
+    def to_pdf(self, path=None):
+        """
+        Exports the chart as PDF.
+
+        Parameters
+        ----------
+
+        path : str or path-like, default None
+            Path where you want to store the pdf. Defaults to the name of the chart in the same
+            directory as the Excel file if the Excel file is stored and to the current working directory otherwise.
+
+        """
+        path = utils.fspath(path)
+        if path is None:
+            # fullname won't work if file is stored on OneDrive
+            directory, _ = os.path.split(self.parent.book.fullname)
+            if directory:
+                path = os.path.join(directory, self.name + '.pdf')
+            else:
+                path = str(Path.cwd() / self.name) + '.pdf'
+        self.impl.to_pdf(path)
 
     def __repr__(self):
         return "<Chart '{0}' in {1}>".format(


### PR DESCRIPTION
Hey, this pull request adds:
- Pdf export for Charts and Ranges
- Quality can be set for all to_pdf methods by a new parameter "quality"
- The new parameter should not brake any existing code as the parameter is optional and has default value xlQualityStandard

I currently don't have access to a Windows machine /w Excel, so there might still be some bugs (will check for that the next days).

On the Mac Version (where i'm developing) both features don't have any effect as the 

```
object.api.ExportAsFixedFormat
```

method is not available via Appscript (might be a MacOS "Feature" as well..)

Happy for feedback, so tell me what you think..

Fixes #1708 and fixes #1697