### PR TITLE
raise a ValueError if the max length of a sheet name is hit

### DIFF
--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -1066,6 +1066,8 @@ class Sheet:
 
     @name.setter
     def name(self, value):
+        if len(value) > 31:
+            raise ValueError(f'The max. length of a sheet name is 31 characters. Yours is {len(value)}.')
         self.impl.name = value
 
     @property


### PR DESCRIPTION
This fixes the current behavior of xlwings hanging instead of raising an error.