### PR TITLE
break out from COM retry when error is not caused by Excel being busy

### DIFF
--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -1066,9 +1066,14 @@ class Sheet:
 
     @name.setter
     def name(self, value):
-        if len(value) > 31:
+        if value in [None, ""]:
+            raise ValueError("A sheet name can't be empty.")
+        elif any(char in value for char in ['\\', '/', '?',  '*', '[', ']']):
+            raise ValueError("A sheet name must not contain any of the following characters: \\, /, ?, *, [, ]")
+        elif len(value) > 31:
             raise ValueError(f'The max. length of a sheet name is 31 characters. Yours is {len(value)}.')
-        self.impl.name = value
+        else:
+            self.impl.name = value
 
     @property
     def names(self):


### PR DESCRIPTION
Previously, writing to a protected sheet (amongst other situations) would cause xlwings to hang forever. Also, improve Sheet name value check (improving #1735).
Closes #1725.