### PR TITLE
gets rid of sheet.activate(), renders template sheets from back to fr…

### DIFF
--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -1065,7 +1065,7 @@ class Book:
         >>> book.sheets[0]['A1:A2'].value = '{{ myvar }}'
         >>> book.render_template(myvar='test')
         """
-        for sheet in self.sheets:
+        for sheet in reversed(self.sheets):
             sheet.render_template(**data)
 
 

--- a/xlwings/pro/reports/main.py
+++ b/xlwings/pro/reports/main.py
@@ -70,7 +70,7 @@ def render_sheet(sheet, **data):
     book = sheet.book
 
     # Shapes aren't properly moved otherwise
-    sheet.activate()
+    sheet.select()
 
     # Inserting rows with Frames changes the print area. Get it here so we can revert at the end.
     print_area = sheet.page_setup.print_area
@@ -322,7 +322,7 @@ def render_template(template, output, book_settings=None, app=None, **data):
         else:
             wb = Book(output)
 
-    for sheet in wb.sheets:
+    for sheet in reversed(wb.sheets):
         render_sheet(sheet, **data)
 
     wb.save()

--- a/xlwings/pro/utils.py
+++ b/xlwings/pro/utils.py
@@ -2,6 +2,7 @@ import os
 import json
 import binascii
 import datetime as dt
+import warnings
 import xlwings  # To prevent circular imports
 
 from ..utils import read_config_sheet
@@ -64,9 +65,11 @@ class LicenseHandler:
         if dt.date.today() > license_valid_until:
             raise xlwings.LicenseError('Your license expired on {}.'.format(license_valid_until.strftime("%Y-%m-%d"))) from None
         if product not in license_info['products']:
-                raise xlwings.LicenseError(f"License key isn't valid for the '{product}' functionality.") from None
+            raise xlwings.LicenseError(f"License key isn't valid for the '{product}' functionality.") from None
         if 'version' in license_info.keys() and license_info['version'] != xlwings.__version__:
             raise xlwings.LicenseError('Your license key is only valid for xlwings v{0}'.format(license_info['version'])) from None
+        if (license_valid_until - dt.date.today()) < dt.timedelta(days=30):
+            warnings.warn(f'Your license key expires in {(license_valid_until - dt.date.today()).days} days.')
         return license_info
 
     @staticmethod


### PR DESCRIPTION
…ont, and warns about expiring license keys. closes #1763,  closes #1764, closes #1758