### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,9 @@ setup(
     name="xlwings",
     version=version,
     url="https://www.xlwings.org",
+    project_urls={
+        "Source": "https://github.com/xlwings/xlwings",
+    },
     license="BSD 3-clause",
     author="Zoomer Analytics LLC",
     author_email="felix.zumstein@zoomeranalytics.com",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)