### PR TITLE
Remove addin_unprotected

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include README.rst
 include xlwings/*.xlsm
 include xlwings/*.xlam
 include xlwings/addin/xlwings.xlam
-include xlwings/addin/xlwings_unprotected.xlam
 include xlwings??-*.dll
 include xlwings/xlwings*.applescript
 include xlwings/Dictionary.cls

--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -10,15 +10,13 @@ xlwings comes with a command line client. On Windows, type the commands into a C
     addin               Run "xlwings addin install" to install the Excel add-
                         in (will be copied to the XLSTART folder). Instead of
                         "install" you can also use "update", "remove" or
-                        "status". Note that this command may take a while. Use
-                        the "--unprotected" flag to install the add-in without
-                        password protection. You can install your custom add-
-                        in by providing the name or path via the --file flag,
-                        e.g. "xlwings add-in install --file custom.xlam or
-                        copy all Excel files in a directory to the XLSTART
-                        folder by providing the path via the --dir flag."
-                        (New in 0.6.0, the unprotected flag was added in 0.20.4
-                        and the --dir flag in 0.24.8)
+                        "status". Note that this command may take a while. You
+                        can install your custom add-in by providing the name
+                        or path via the --file/-f flag, e.g. "xlwings add-in
+                        install -f custom.xlam or copy all Excel files in a
+                        directory to the XLSTART folder by providing the path
+                        via the --dir flag."
+                        (New in 0.6.0, the --dir flag was added in 0.24.8)
     quickstart          Run "xlwings quickstart myproject" to create a folder
                         called "myproject" in the current directory with an
                         Excel file and a Python file, ready to be used. Use
@@ -76,8 +74,8 @@ xlwings comes with a command line client. On Windows, type the commands into a C
                         overwrite the local version of the modules with those
                         from Excel, run "xlwings vba export". To overwrite the
                         VBA modules in Excel with their local versions, run
-                        "xlwings vba import". The "--file" flag allows you to
-                        specify a file path instead of using the active
+                        "xlwings vba import". The "--file/-f" flag allows you
+                        to specify a file path instead of using the active
                         Workbook. Requires "Trust access to the VBA project
                         object model" enabled. NOTE: Whenever you change
                         something in the VBA editor (such as the layout of a

--- a/scripts/build_excel_files.py
+++ b/scripts/build_excel_files.py
@@ -19,9 +19,7 @@ from Aspose.Cells import Workbook, License
 this_dir = os.path.dirname(os.path.abspath(__file__))
 par_dir = os.path.join(this_dir, os.path.pardir)
 addin_path = os.path.join(par_dir, "xlwings", "addin", "xlwings.xlam")
-addin_unprotected_path = os.path.join(
-    par_dir, "xlwings", "addin", "xlwings_unprotected.xlam"
-)
+
 standalone_path = os.path.join(par_dir, "xlwings", "quickstart_standalone.xlsm")
 myaddin_ribbon_path = os.path.join(par_dir, "xlwings", "quickstart_addin_ribbon.xlam")
 myaddin_path = os.path.join(par_dir, "xlwings", "quickstart_addin.xlam")
@@ -150,11 +148,6 @@ main_code = addin_modules["Main"].get_Codes()
 main_code = set_version_strings(main_code)
 addin_modules["Main"].set_Codes(main_code)
 addin_wb.Save(addin_path)
-
-# Create an unprotected copy of the xlwings add-in (without password)
-addin_unprotected_wb = Workbook(addin_path)
-addin_unprotected_wb.VbaProject.Protect(False, None)
-addin_unprotected_wb.Save(addin_unprotected_path)
 
 # Save standalone module
 standalone_code = produce_single_module(addin_modules, custom_addin=False)

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ setup(
             "*.xlam",
             "*.applescript",
             "addin/xlwings.xlam",
-            "addin/xlwings_unprotected.xlam",
             "js/xlwings.*",
             "quickstart_fastapi/*.*",
         ]

--- a/xlwings/cli.py
+++ b/xlwings/cli.py
@@ -34,7 +34,7 @@ def get_addin_dir():
 
 def addin_install(args):
     xlwings_addin_target_path = os.path.join(get_addin_dir(), "xlwings.xlam")
-    addin_name = "xlwings_unprotected.xlam" if args.unprotected else "xlwings.xlam"
+    addin_name = "xlwings.xlam"
     try:
         if args.file:
             custom_addin_source_path = os.path.abspath(args.file)
@@ -721,10 +721,9 @@ def main():
         help='Run "xlwings addin install" to install the Excel add-in '
         '(will be copied to the XLSTART folder). Instead of "install" you can '
         'also use "update", "remove" or "status". Note that this command '
-        'may take a while. Use the "--unprotected" flag to install the '
-        "add-in without password protection. You can install your custom add-in "
-        "by providing the name or path via the --file flag, "
-        'e.g. "xlwings add-in install --file custom.xlam or copy all Excel '
+        "may take a while. You can install your custom add-in "
+        "by providing the name or path via the --file/-f flag, "
+        'e.g. "xlwings add-in install -f custom.xlam or copy all Excel '
         "files in a directory to the XLSTART folder by providing the path "
         'via the --dir flag."',
     )
@@ -737,12 +736,7 @@ def main():
     )
 
     addin_install_parser = addin_subparsers.add_parser("install")
-    addin_install_parser.add_argument(
-        "-u",
-        "--unprotected",
-        action="store_true",
-        help="Install the add-in without the password protection.",
-    )
+
     addin_install_parser.add_argument("-f", "--file", default=None, help=file_arg_help)
     addin_install_parser.add_argument("-d", "--dir", default=None, help=dir_arg_help)
     addin_install_parser.set_defaults(func=addin_install)
@@ -883,7 +877,7 @@ def main():
     code_parser = subparsers.add_parser(
         "code",
         help='Run "xlwings code embed" to embed all Python modules of the '
-        """workbook's dir in your active Excel file. Use the "--file" flag to """
+        """workbook's dir in your active Excel file. Use the "--file/-f" flag to """
         "only import a single file by providing its path. Requires "
         "xlwings PRO.",
     )
@@ -949,8 +943,9 @@ def main():
         To overwrite the local version of the modules with those from Excel,
         run "xlwings vba export". To overwrite the VBA modules in Excel with their local
         versions, run "xlwings vba import".
-        The "--file" flag allows you to specify a file path instead of using the active
-        Workbook. Requires "Trust access to the VBA project object model" enabled.
+        The "--file/-f" flag allows you to specify a file path instead of using the
+        active Workbook. Requires "Trust access to the VBA project object model" 
+        enabled.
         NOTE: Whenever you change something in the VBA editor (such as the layout of a
         form or the properties of a module), you have to run "xlwings vba export".
         """,


### PR DESCRIPTION
* Removes `xlwings addin install --unprotected`
* Will keep the package small since the addin will become bigger with the remote interpreter support
* Can still be done by manually going into the addin and removing the password protection