### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/reports.rst
+++ b/docs/reports.rst
@@ -5,7 +5,7 @@ xlwings Reports
 
 This feature requires xlwings :bdg-secondary:`PRO`.
 
-xlwings Reports is a solution for template-based Excel and PDF reporting, making the generation of pixel-perfect factsheets really simple. xlwings Reports allows business users without Python knowledge to create and maintain Excel templates without having to rely on a Python developer after the intial setup has been done: xlwings Reports separates the Python code (pre- and post-processing) from the Excel template (layout/formatting).
+xlwings Reports is a solution for template-based Excel and PDF reporting, making the generation of pixel-perfect factsheets really simple. xlwings Reports allows business users without Python knowledge to create and maintain Excel templates without having to rely on a Python developer after the initial setup has been done: xlwings Reports separates the Python code (pre- and post-processing) from the Excel template (layout/formatting).
 
 xlwings Reports supports all commonly required components:
 

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -196,7 +196,7 @@ v0.24.3 (Jul 15, 2021)
     with xw.App(visible=True) as app:
         print(app.books)
 
-* :bdg-info:`Enhancement` :meth:`mysheet.pictures.add <xlwings.main.Pictures.add>` now accepts a new ``anchor`` argument that you can use as an alternative to ``top``/``left`` to position the picture by providing an achor range object, e.g.: ``mysheet.pictures.add(img, anchor=mysheet['A1'])`` (:issue:`1648`).
+* :bdg-info:`Enhancement` :meth:`mysheet.pictures.add <xlwings.main.Pictures.add>` now accepts a new ``anchor`` argument that you can use as an alternative to ``top``/``left`` to position the picture by providing an anchor range object, e.g.: ``mysheet.pictures.add(img, anchor=mysheet['A1'])`` (:issue:`1648`).
 * :bdg-warning:`Bug Fix` macOS: Plots are now sent to Excel in PDF format when you set ``format='vector'`` which is supporting transparency unlike the previously used eps format (:issue:`1647`).
 * :bdg-secondary:`PRO` :bdg-info:`Enhancement` :meth:`mybook.to_pdf <xlwings.Book.to_pdf>` now accepts a ``layout`` parameter so you can "print" your reports onto a PDF with your corporate layout including headers, footers and borderless graphics. See :ref:`reports_pdf_layout`.
 


### PR DESCRIPTION
There are small typos in:
- docs/reports.rst
- docs/whatsnew.rst

Fixes:
- Should read `initial` rather than `intial`.
- Should read `anchor` rather than `achor`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md