### PR TITLE
Add @xw.cache decorator for UDFs

### DIFF
--- a/xlwings/__init__.py
+++ b/xlwings/__init__.py
@@ -80,6 +80,7 @@ except (ImportError, LicenseError):
 if sys.platform.startswith("win"):
     from .udfs import (
         xlfunc as func,
+        xlcache as cache,
         xlsub as sub,
         xlret as ret,
         xlarg as arg,
@@ -102,6 +103,16 @@ if sys.platform.startswith("win"):
     except:
         pass
 else:
+
+    def cache(f=None, *args, **kwargs):
+        @wraps(f)
+        def inner(f):
+            return f
+
+        if f is None:
+            return inner
+        else:
+            return inner(f)
 
     def func(f=None, *args, **kwargs):
         @wraps(f)

--- a/xlwings/udfs.py
+++ b/xlwings/udfs.py
@@ -144,6 +144,7 @@ def xlfunc(f=None, **kwargs):
             xlf = f.__xlfunc__ = {}
             xlf["name"] = f.__name__
             xlf["sub"] = False
+            xlf["cache"] = False
             xlargs = xlf["args"] = []
             xlargmap = xlf["argmap"] = {}
             sig = func_sig(f)
@@ -184,6 +185,18 @@ def xlfunc(f=None, **kwargs):
         )
         f.__xlfunc__["volatile"] = check_bool("volatile", default=False, **kwargs)
         f.__xlfunc__["async_mode"] = get_async_mode(**kwargs)
+        return f
+
+    if f is None:
+        return inner
+    else:
+        return inner(f)
+
+
+def xlcache(f=None, **kwargs):
+    def inner(f):
+        f = xlfunc(**kwargs)(f)
+        f.__xlfunc__["cache"] = True
         return f
 
     if f is None:
@@ -578,6 +591,7 @@ def generate_vba_wrapper(module_name, module, f, xl_workbook):
         if hasattr(svar, "__xlfunc__"):
             xlfunc = svar.__xlfunc__
             xlret = xlfunc["ret"]
+            xlcache = xlfunc["cache"]
             fname = xlfunc["name"]
             call_in_wizard = xlfunc["call_in_wizard"]
             volatile = xlfunc["volatile"]
@@ -619,6 +633,17 @@ def generate_vba_wrapper(module_name, module, f, xl_workbook):
                         )
                     if volatile:
                         vba.writeln("Application.Volatile")
+                    if xlcache:
+                        vba.writeln("Dim Key As String")
+                        vba.writeln(f'Key = "{fname}"')
+                        for arg in xlfunc["args"]:
+                            arg_name = arg["vba"] or arg["name"]
+                            vba.writeln(f"Key = Key & vbTab & {arg_name}")
+                        vba.writeln("If UdfCache Is Nothing Then Set UdfCache = NewDictionary")
+                        vba.writeln("If UdfCache.Exists(Key) Then")
+                        vba.writeln(f"    {fname} = UdfCache(Key)")
+                        vba.writeln("    Exit Function")
+                        vba.writeln("End If")
 
                 if vararg != "":
                     vba.writeln("Dim argsArray() As Variant")
@@ -701,6 +726,7 @@ def generate_vba_wrapper(module_name, module, f, xl_workbook):
                             args_vba=args_vba,
                             vba_workbook=vba_workbook,
                         )
+                        vba.writeln(f"UdfCache.Add Key, {fname}")
                         vba.writeln("Exit " + ftype)
                     with vba.block("#Else"):
                         vba.writeln(
@@ -710,6 +736,7 @@ def generate_vba_wrapper(module_name, module, f, xl_workbook):
                             fname=fname,
                             args_vba=args_vba,
                         )
+                        vba.writeln(f"UdfCache.Add Key, {fname}")
                         vba.writeln("Exit " + ftype)
                     vba.writeln("#End If")
 
@@ -735,6 +762,7 @@ def import_udfs(module_names, xl_workbook):
     vba.writeln(
         """#Const App = "Microsoft Excel" 'Adjust when using outside of Excel"""
     )
+    vba.writeln("Private UdfCache As Dictionary")
 
     for module_name in module_names:
         module = get_udf_module(module_name, xl_workbook)


### PR DESCRIPTION
I was not able to tell Excel to use the repository code, so I edited the modules installed with pip from `envs\xlwings\Lib\site-packages\xlwings\udfs.py` and tested that the UDF import to Excel was working well.

When the import was working, I copied the code to the modules in the repository, committed and created the pull request.

I was not able to edit the xlwings.xlam file from the repository. In order for these changes to work, the following function must be added to the module `utils.bas`:
```VBA
Function NewDictionary(ParamArray Args()) As Dictionary
  Dim I As Integer
  Set NewDictionary = New Dictionary
  For I = 0 To UBound(Args) Step 2
    NewDictionary.Add Args(I), Args(I + 1)
  Next I
End Function
```