### PR TITLE
Switch CLI build back to 64bit [build-cli]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -254,7 +254,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-          architecture: 'x86'
           cache: 'pip'
       - name: Get Certificate
         id: write_file


### PR DESCRIPTION
Otherwise cryptography, a dependency of msal, shows a warning.