### PR TITLE
pytest as dependency for development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ all = [
     "flask",
     "requests",
     "pdfrw",
+    "pytest"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ reports = [
     "pdfrw"
 ]
 all = [
+    "black",
     "Jinja2",
     "pandas",
     "matplotlib",
@@ -47,7 +48,7 @@ all = [
     "flask",
     "requests",
     "pdfrw",
-    "pytest"
+    "pytest",
 ]
 
 [project.scripts]

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ extras_require = {
         "flask",
         "requests",
         "pdfrw",
+        "pytest"
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ else:
 extras_require = {
     "reports": ["Jinja2", "pdfrw"],
     "all": [
+        "black",
         "Jinja2",
         "pandas",
         "matplotlib",
@@ -50,7 +51,7 @@ extras_require = {
         "flask",
         "requests",
         "pdfrw",
-        "pytest"
+        "pytest",
     ],
 }
 


### PR DESCRIPTION
As the developguide of xlwings states, xlwings is in transition to pytest. Therefor installing it with the 
```shell
pip install -e ".[all]"
```
command should also install pytest. 