### PR TITLE
Avoid the packaged application flashing black cmdline window.

### DIFF
--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -514,6 +514,7 @@ class Apps(base_classes.Apps):
             split('tasklist /FI "IMAGENAME eq EXCEL.exe"'),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            shell=True,
             encoding="utf-8",
         )
 
@@ -531,6 +532,7 @@ class Apps(base_classes.Apps):
                 split(f"taskkill /PID {pid} /F"),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
+                shell=True,
                 encoding="utf-8",
             )
 

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -514,7 +514,7 @@ class Apps(base_classes.Apps):
             split('tasklist /FI "IMAGENAME eq EXCEL.exe"'),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            shell=True,
+            creationflags=0x08000000,
             encoding="utf-8",
         )
 
@@ -532,7 +532,7 @@ class Apps(base_classes.Apps):
                 split(f"taskkill /PID {pid} /F"),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                shell=True,
+                creationflags=0x08000000,
                 encoding="utf-8",
             )
 

--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -514,7 +514,7 @@ class Apps(base_classes.Apps):
             split('tasklist /FI "IMAGENAME eq EXCEL.exe"'),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            creationflags=0x08000000,
+            creationflags=subprocess.CREATE_NO_WINDOW,
             encoding="utf-8",
         )
 
@@ -532,7 +532,7 @@ class Apps(base_classes.Apps):
                 split(f"taskkill /PID {pid} /F"),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                creationflags=0x08000000,
+                creationflags=subprocess.CREATE_NO_WINDOW,
                 encoding="utf-8",
             )
 


### PR DESCRIPTION
```python
import xlwings as xw
```

Package an exe application through `pyinstaller -w main.py` ,  main.py with the above code,  because the subprocess `tasklist` command is called, a black cmdline window will flash every time when the program exits.