### PR TITLE
Configuration hierarchy and Troubleshooting Python not found

### DIFF
--- a/docs/addin.rst
+++ b/docs/addin.rst
@@ -81,6 +81,20 @@ With environment variables, you can set dynamic paths e.g. to your interpreter o
 * On Windows, you can use all environment variables like so: ``%USERPROFILE%\Anaconda``.
 * On macOS, the following special variables are supported: ``$HOME``, ``$APPLICATIONS``, ``$DOCUMENTS``, ``$DESKTOP``.
 
+.. _config_hierarchy:
+
+Config Hierarchy
+----------------
+
+The configuration hierachy to which xlwings listens is as follows. You can read more information about each config below. Where the lower takes precedence over the higher.
+
+.. code-block:: bash
+
+    .
+    └── xlwings-ribbon-config - If xlwings ribbon is installed
+        └── workbook-directory-config - If a file named xlwings.conf is present
+            └── xlwing.conf-sheet - If a sheet named xlwings.conf is present and active
+
 .. _user_config:
 
 User Config: Ribbon/Config File
@@ -132,7 +146,7 @@ Workbook Config: xlwings.conf Sheet
 Workbook specific settings will override global (Ribbon) and workbook directory config files: 
 Workbook specific settings are set by listing the config key/value pairs in a sheet with the name ``xlwings.conf``.
 When you create a new project with ``xlwings quickstart``, it'll already have such a sheet but you need to rename
-it to ``xlwings.conf`` to make it active.
+it from ``_xlwings.conf`` to ``xlwings.conf`` to make it active.
 
 
 .. figure:: ./images/workbook_config.png

--- a/docs/addin.rst
+++ b/docs/addin.rst
@@ -95,7 +95,7 @@ The configuration hierachy to which xlwings listens is as follows:
         └── workbook-directory-config - If a file named xlwings.conf is present
             └── xlwing.conf-sheet - If a sheet named xlwings.conf is present and active
 
-You can read more information about each config below. Where the lower takes precedence over the higher.
+Where the lower takes precedence over the higher. You can read more information about each config below. 
 
 .. _user_config:
 

--- a/docs/addin.rst
+++ b/docs/addin.rst
@@ -86,7 +86,7 @@ With environment variables, you can set dynamic paths e.g. to your interpreter o
 Config Hierarchy
 ----------------
 
-The configuration hierachy to which xlwings listens is as follows. You can read more information about each config below. Where the lower takes precedence over the higher.
+The configuration hierachy to which xlwings listens is as follows: 
 
 .. code-block:: bash
 
@@ -94,6 +94,8 @@ The configuration hierachy to which xlwings listens is as follows. You can read 
     └── xlwings-ribbon-config - If xlwings ribbon is installed
         └── workbook-directory-config - If a file named xlwings.conf is present
             └── xlwing.conf-sheet - If a sheet named xlwings.conf is present and active
+
+You can read more information about each config below. Where the lower takes precedence over the higher.
 
 .. _user_config:
 

--- a/docs/pro/release.rst
+++ b/docs/pro/release.rst
@@ -67,11 +67,9 @@ The release command is part of the xlwings CLI (command-line client) and will pr
 To work with the release command, you should have your workbook in the ``xlsm`` format next to your Python code::
 
     myworkbook.xlsm
-    packages
-    src
-      mymodule_one.py
-      mypackage/
-        mymodule_two.py
+    mymodule_one.py
+    mypackage/
+      mymodule_two.py
     ...
 
 Make sure that your Excel workbook is the active workbook, then run the following command on a Command/Anaconda Prompt::

--- a/docs/pro/release.rst
+++ b/docs/pro/release.rst
@@ -67,9 +67,11 @@ The release command is part of the xlwings CLI (command-line client) and will pr
 To work with the release command, you should have your workbook in the ``xlsm`` format next to your Python code::
 
     myworkbook.xlsm
-    mymodule_one.py
-    mypackage/
-      mymodule_two.py
+    packages
+    src
+      mymodule_one.py
+      mypackage/
+        mymodule_two.py
     ...
 
 Make sure that your Excel workbook is the active workbook, then run the following command on a Command/Anaconda Prompt::

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -22,3 +22,15 @@ Issue: Files that are saved on OneDrive or SharePoint cause an error to pop up
 Solution:
 
 See the dedicated page about how to configure OneDrive and Sharepoint: :ref:`onedrive_sharepoint`.
+
+Issue: Python was not found; run without arguments to install from the Microsoft Store, or disable this shortcut from Settings > Manage App Execution Aliases.
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+Cause:
+
+The Python interpreter is not correctly installed or the configuration does not point to the Python interpreter.
+
+Solution:
+
+1) Verifiy that an interpreter is installed. This can be an installation provided by conda, virtual environment or the xlwings-installer(requires pro)
+2) Check the configuration of xlwings accoring to its hierachy :ref:`_config_hierarchy:`

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -33,4 +33,4 @@ The Python interpreter is not correctly installed or the configuration does not 
 Solution:
 
 1) Verifiy that an interpreter is installed. This can be an installation provided by conda, virtual environment or the xlwings-installer(requires pro)
-2) Check the configuration of xlwings accoring to its hierachy :ref:`_config_hierarchy:`
+2) Check the configuration of xlwings accoring to its hierachy :ref:`config_hierarchy`


### PR DESCRIPTION
In attempt to help future me. 

- Make it more visually distinct the hierarchy of the different settings. It is explained in words, perhaps making it visual (perhaps even using a diagram?) would make it less overlooked. 
- Add a troubleshooting message about Python not found while linking to the configuration hierarchy. 