### PR TITLE
use preferredencoding instead of utf-8 with apps.cleanup()

### DIFF
--- a/xlwings/_xlwindows.py
+++ b/xlwings/_xlwindows.py
@@ -1,4 +1,5 @@
 import atexit
+import locale
 import os
 import subprocess
 import sys
@@ -515,7 +516,7 @@ class Apps(base_classes.Apps):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             creationflags=subprocess.CREATE_NO_WINDOW,
-            encoding="utf-8",
+            encoding=locale.getpreferredencoding(),
         )
 
         all_pids = set()
@@ -533,7 +534,7 @@ class Apps(base_classes.Apps):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 creationflags=subprocess.CREATE_NO_WINDOW,
-                encoding="utf-8",
+                encoding=locale.getpreferredencoding(),
             )
 
     def __iter__(self):


### PR DESCRIPTION
In the hope to fix `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xcf in position 4: invalid continuation byte` that can happen on computer with Chinese regional settings.