### PR TITLE
Make activation explicit

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -40,6 +40,7 @@ class TestApp(TestBase):
             with self.assertRaises(Exception):
                 self.app1.activate()
         else:
+            self.app2.activate()
             self.assertEqual(self.app2, xw.apps.active)
             self.app1.activate()
             self.assertEqual(self.app1, xw.apps.active)


### PR DESCRIPTION
If I understand it correctly, the test relied upon the fact that `app2` was added last by `class TestBase(unittest.TestCase):` and therefore should be active, correct?

So perhaps make it more explicit (as in [zen rule nr 2](https://peps.python.org/pep-0020/) 😉)? It helps pass the test in my case. 

Related to #2261 