### PR TITLE
Developer guide - xlwings_license_key_secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ node_modules
 .parcel-cache
 
 .hypothesis/
+debug.ipynb

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -130,6 +130,8 @@ Currently, we're migrating to `pytest`, so you'll find a mix between `unittest` 
 Running the whole tests suite is currently broken, so it's recommended to run single modules instead.
 See e.g., `test_font.py` for the new style of tests that are also fast.
 
+For running the xlwings pro related tests the `XLWINGS_LICENSE_KEY_SECRET` should be set. This can be done by setting the [developer](https://docs.xlwings.org/en/latest/pro/license_key.html#activate-a-developer-key) key to `noncommercial`
+
 ## Docs
 
 ### Build locally


### PR DESCRIPTION
Little improvement to the developer guide, so that contributing developers now that the key has to be set to `noncommercial` instead of their actual license key for running xlwings pro related tests. 

Explains #2265 