### PR TITLE
activate app before testing if it's active

### DIFF
--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -1,7 +1,4 @@
 import os
-import pytest
-
-
 import xlwings as xw
 
 from .common import TestBase, this_dir

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -1,5 +1,6 @@
 import os
-import unittest
+import pytest
+
 
 import xlwings as xw
 
@@ -13,6 +14,7 @@ except ImportError:
 
 class TestActive(TestBase):
     def test_apps_active(self):
+        self.app2.activate()
         self.assertEqual(xw.apps.active, self.app2)
 
     def test_books_active(self):
@@ -75,6 +77,3 @@ class TestView(TestBase):
         self.assertEqual(xw.books.count, n_books)
         self.assertEqual(xw.books[0].sheets[0].range("A1:C1").value, [1.0, 2.0, 3.0])
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -73,4 +73,3 @@ class TestView(TestBase):
         xw.view([1, 2, 3], sheet=xw.books[0].sheets[0])
         self.assertEqual(xw.books.count, n_books)
         self.assertEqual(xw.books[0].sheets[0].range("A1:C1").value, [1.0, 2.0, 3.0])
-

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -1,4 +1,5 @@
 import os
+
 import xlwings as xw
 
 from .common import TestBase, this_dir


### PR DESCRIPTION
Similar to #2262. The test implicitly assumed that the last created app should also be the activated one. 

Also because of the transition to pytest, the `import unittest` is removed. Is the 
```Python
if __name__ == "__main__":
    unittest.main()
```
needed as I haven't seen it in `test_font.py` as this was mentioned as the example module transitioned to pytest. 