### PR TITLE
Server fixes: removed required globalThis vars in JS and custom functions date format improvements

### DIFF
--- a/xlwings/pro/_xlofficejs.py
+++ b/xlwings/pro/_xlofficejs.py
@@ -32,7 +32,7 @@ from .. import utils
 def datetime_to_formatted_number(datetime_object, date_format, runtime):
     # https://learn.microsoft.com/en-us/javascript/api/requirement-sets/excel/custom-functions-requirement-sets
     serial = utils.datetime_to_xlserial(datetime_object)
-    if float(runtime) < 1.4:
+    if float(runtime) < 1.4 or date_format is None:
         return serial
     else:
         return {

--- a/xlwings/pro/custom_functions_code.js
+++ b/xlwings/pro/custom_functions_code.js
@@ -19,7 +19,7 @@ let contentLanguage;
 
 Office.onReady(function (info) {
   // Socket.io
-  const socket = globalThis.socket;
+  const socket = globalThis.socket ? globalThis.socket : null;
 
   if (socket !== null) {
     socket.on("disconnect", () => {
@@ -115,7 +115,8 @@ async function base() {
   // Normal functions communicate via REST API
   let headers = {};
   headers["Content-Type"] = "application/json";
-  headers["Authorization"] = await globalThis.getAuth();
+  headers["Authorization"] =
+    typeof globalThis.getAuth === "function" ? await globalThis.getAuth() : "";
 
   let response = await fetch(
     window.location.origin + "placeholder_custom_functions_call_path",

--- a/xlwings/pro/udfs_officejs.py
+++ b/xlwings/pro/udfs_officejs.py
@@ -145,12 +145,13 @@ def convert(result, ret_info, data):
     if "date_format" not in ret_info["options"]:
         date_format = os.getenv("XLWINGS_DATE_FORMAT")
         if date_format is None:
-            try:
-                date_format = locale_to_shortdate[data["content_language"].lower()]
-            except KeyError:
-                raise KeyError(
-                    f'Locale {data["content_language"].lower()} not found and XLWINGS_DATE_FORMAT is not set'
-                )
+            date_format = locale_to_shortdate.get(data["content_language"].lower())
+            logger.warning(
+                f"Locale {data['content_language'].lower()} not found, so custom "
+                "functions won't format dates automatically. Please open an issue with "
+                "this warning on https://github.com/xlwings/xlwings/issues. In the "
+                "meantime, you can set the XLWINGS_DATE_FORMAT env var to fix that."
+            )
         ret_info["options"]["date_format"] = date_format
     ret_info["options"]["runtime"] = data["runtime"]
     result = conversion.write(result, None, ret_info["options"], engine_name="officejs")


### PR DESCRIPTION
* globalThis.getAuth and globalThis.socket are no longer required to be set in taskpane.html if unused
* custom function handle missing locals more gracefully with a warning instead of an error