### PR TITLE
Fix prepare_sys_path case sensitivity for qemu shared folder

### DIFF
--- a/xlwings/utils.py
+++ b/xlwings/utils.py
@@ -467,7 +467,19 @@ def prepare_sys_path(args_string):
         paths += args[6:]
 
     if paths:
-        sys.path[0:0] = list(set(paths))
+        def toRealCase(path):
+            if os.name == 'nt':
+                parts=Path(path).parts
+                drive=parts[0]
+                result_path=Path({drv.lower():drv for drv in os.listdrives()}[drive])
+                for path_elem in parts[1:]:
+                    try:
+                        result_path/={elem.lower():elem for elem in os.listdir(result_path)}[path_elem]
+                    except KeyError:
+                        result_path/=path_elem
+                    return str(result_path)
+            return path
+        sys.path[0:0] = [toRealCase(path) for path in set(paths) if path]
 
 
 @lru_cache(None)


### PR DESCRIPTION
For some reason, mounted shared folders on a Windows guest's remote drive appear to be case-sensitive.
This pull request addresses the issue by recreating system paths with their original case, specifically for Windows.
Additionally, the `os.realpath` method does not work in this context, so the implementation uses `os.listdrives` (python >= 3.12) and `os.listdir` to reconstruct the correct path.