### PR TITLE
Revert "allow to specify the xlwings version for the deploy key"

### DIFF
--- a/xlwings/pro/utils.py
+++ b/xlwings/pro/utils.py
@@ -26,8 +26,6 @@ import time
 import warnings
 from functools import lru_cache
 
-from packaging.version import Version
-
 import xlwings  # To prevent circular imports
 
 from ..utils import read_config_sheet
@@ -159,25 +157,18 @@ class LicenseHandler:
         return license_info
 
     @staticmethod
-    def create_deploy_key(version=None):
+    def create_deploy_key():
         license_info = LicenseHandler.validate_license("pro", license_type="developer")
         if license_info["license_type"] == "noncommercial":
             return "noncommercial"
-
-        if version and Version(version) <= Version(xlwings.__version__):
-            license_version = version
-        else:
-            license_version = xlwings.__version__
-
         license_dict = json.dumps(
             {
-                "version": license_version,
+                "version": xlwings.__version__,
                 "products": license_info["products"],
                 "valid_until": "2999-12-31",
                 "license_type": "deploy_key",
             }
         ).encode()
-
         if LicenseHandler.get_license().startswith("gA"):
             # Legacy
             cipher_suite = LicenseHandler.get_cipher()


### PR DESCRIPTION
This reverts commit b1e0c6843afb3c01d6a9bf2230708d93af471ca2.

```
from packaging.version import Version
```

requires Python 3.10+, but we have already `xlwings.utils.VersionNumber` that we can use.
Anyhow, instead of providing the version argument, it's easier to allow for deploy keys to be valid for any version <= the deploy key version.