### PR TITLE
2580 add optional dependency of watchgod

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ all = [
     "pytest",
     "mistune",
 ]
+vba_edit = ["watchgod"]
 
 [project.scripts]
 xlwings = "xlwings.cli:main"

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ extras_require = {
         "pytest",
         "mistune",
     ],
+    "vba_edit": ["watchgod"],
 }
 
 if os.getenv("BUILD_RUST", "0") == "1":


### PR DESCRIPTION
Closes #2580

Simply adds a new optional dependency to pyproject.toml of the watchgod library enablings the usage of `xlwings vba edit` via uv:

uvx --from 'xlwings[vba_edit]' xlwings vba edit"

To test (before it gets merged) use the following:
`uvx --from "git+https://github.com/MEMAndersen/xlwings.git@2580-Add-optional-dependency-of-watchgod[vba_edit]" xlwings vba edit`

See also https://docs.astral.sh/uv/guides/tools/#requesting-extras

When #1963 is adressed the optional dependency should be updated

It is my first time contributing to anything so please guide or correct me if i am doing something wrong