### PR TITLE
don't do version check with office.js

### DIFF
--- a/xlwings/pro/_xlremote.py
+++ b/xlwings/pro/_xlremote.py
@@ -272,7 +272,7 @@ class Book(base_classes.Book):
         self.books = books
         self._api = api
         self._json = {"actions": []}
-        if api["version"] != __version__:
+        if api["version"] != __version__ and api["client"] != "Office.js":
             raise XlwingsError(
                 f"Your xlwings version is different on the client ({api['version']}) "
                 f"and server ({__version__})."
@@ -764,7 +764,6 @@ class Range(base_classes.Range):
         )
 
     def copy(self, destination=None):
-        # TODO: introduce the new copy_from from Office Scripts
         if destination is None:
             raise XlwingsError("range.copy() requires a destination argument.")
         self.append_json_action(

--- a/xlwings/pro/udfs_officejs.py
+++ b/xlwings/pro/udfs_officejs.py
@@ -296,7 +296,7 @@ async def custom_functions_call(
     if current_user:
         await check_user_roles(current_user, required_roles)
 
-    if data["version"] != __version__:
+    if data["version"] != __version__ and data["client"] != "Office.js":
         raise XlwingsError(
             f"xlwings version mismatch (client: {data['version']} backend: {__version__}): please restart Excel or "
             "right-click on the task pane and select 'reload'!"


### PR DESCRIPTION
- xlwings Server always serves the correct version anyways as the frontend code is now part of xlwings-server (except if there are caching issues).
- xlwings Lite requires flexibility to be able to choose the xlwings version freely. Meaning that xlwings.js should be downward compatiable down to a minimimally required version, which shouldn't be any issue.