### PR TITLE
Fix fullname_url_to_local_path not working for files in synced subdir…

### DIFF
--- a/xlwings/utils.py
+++ b/xlwings/utils.py
@@ -618,9 +618,9 @@ def fullname_url_to_local_path(
         # Windows registry
         url_to_mount = get_url_to_mount()
         mount_point = None
-        for url_namespace, mount_point in url_to_mount.items():
-            if url.startswith(url_namespace):
-                local_path = Path(mount_point) / url[len(url_namespace) :]
+        for remote_path, mount_point in url_to_mount.items():
+            if url.startswith(remote_path):
+                local_path = Path(mount_point) / url[len(remote_path) :].removeprefix("/")
                 if local_path.is_file():
                     return str(local_path)
         # Horrible fallback
@@ -749,8 +749,9 @@ def get_url_to_mount():
                     ) as key:
                         try:
                             mount_point, _ = winreg.QueryValueEx(key, "MountPoint")
-                            url_namespace, _ = winreg.QueryValueEx(key, "URLNamespace")
-                            url_to_mount[url_namespace] = mount_point
+                            remote_path, _ =  winreg.QueryValueEx(key, "FullRemotePath")
+                            remote_path = re.sub(r"^https:/(?!/)", "https://", remote_path)
+                            url_to_mount[remote_path] = mount_point
                         except FileNotFoundError:
                             pass
         except FileNotFoundError:


### PR DESCRIPTION
As the title says, this fixes `fullname_url_to_local_path` (and thus the whole "Open SharePoint  files" functionality) for the case when the user syncs a subdirectory instead of an entire SharePoint  library.
Consider the following example setup: There is a SharePoint library `library` containing a folder `synced directory`. Rather than syncing `library`, the user opts to only sync `synced directory` (via the "Add shortcut to OneDrive` button). The relevant paths then look like this:

|Type|Path/URL|
|------|-----|
|Local path|`C:\Users\username\OneDrive - compancy\synced directory\subdirectory\workbook.xlsx`|
|Full URL|`https://company.sharepoint.com/sites/library/Shared Documents/synced directory/subdirectory/workbook.xlsx`|
|`MountPoint`|`C:\Users\username\OneDrive - company\synced directory`|
|`UrlNamespace`|`https://company.sharepoint.com/sites/library/Shared Documents/`|
|`FullRemotePath`|`https:/company.sharepoint.com/sites/library/Shared Documents/synced directory`|

This means that the relevant URL prefix must include `synced directory`. The current version of the code doesn't do this, and as a result, the "predicted" `local_path` is this (notice the duplication of `synced directory`):

`C:\Users\username\OneDrive - compancy\synced directory\synced directory\subdirectory\workbook.xlsx`

To fix this, it's necessary to use `FullRemotePath` rather than `UrlNamespace`. Unfortunately, this for some reason has the prefix `https:/` rather than `https://` (at least on my computers), so the patch fixes the URL accordingly. The last issue is that `FullRemotePath` doesn't end in a `/`, so after the prefix is removed in line 623, any leading slashes also need to go (otherwise, the path concatenation results in `C:\synced directory\subdirectory\workbook.xlsx`)