### PR TITLE
type fixes for func/script decorators

### DIFF
--- a/xlwings/__init__.py
+++ b/xlwings/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, overload
 
 __version__ = "0.0.0"
 
@@ -156,6 +156,14 @@ elif sys.platform.startswith("win") and has_pywin32:
         pass
 else:
 
+    @overload
+    def func(f: _F) -> _F:
+        ...
+
+    @overload
+    def func(f: None = ..., *args: Any, **kwargs: Any) -> Callable[[_F], _F]:
+        ...
+
     def func(f: _F | None = None, *args: Any, **kwargs: Any) -> _F | Callable[[_F], _F]:
         def inner(f: _F) -> _F:
             return f
@@ -165,6 +173,14 @@ else:
         else:
             return inner(f)
 
+    @overload
+    def sub(f: _F) -> _F:
+        ...
+
+    @overload
+    def sub(f: None = ..., *args: Any, **kwargs: Any) -> Callable[[_F], _F]:
+        ...
+
     def sub(f: _F | None = None, *args: Any, **kwargs: Any) -> _F | Callable[[_F], _F]:
         def inner(f: _F) -> _F:
             return f
@@ -173,6 +189,14 @@ else:
             return inner
         else:
             return inner(f)
+
+    @overload
+    def script(f: _F) -> _F:
+        ...
+
+    @overload
+    def script(f: None = ..., *args: Any, **kwargs: Any) -> Callable[[_F], _F]:
+        ...
 
     def script(
         f: _F | None = None, *args: Any, **kwargs: Any

--- a/xlwings/pro/udfs_officejs.py
+++ b/xlwings/pro/udfs_officejs.py
@@ -28,6 +28,7 @@ from typing import (
     get_args,
     get_origin,
     get_type_hints,
+    overload,
 )
 
 _F = TypeVar("_F", bound=Callable[..., Any])
@@ -83,6 +84,16 @@ def extract_type_and_annotations(type_hint):
     else:
         top_level_type = origin or type_hint
         return top_level_type, []
+
+
+@overload
+def xlfunc(f: _F) -> _F:
+    ...
+
+
+@overload
+def xlfunc(f: None = ..., **kwargs: Any) -> Callable[[_F], _F]:
+    ...
 
 
 def xlfunc(f: _F | None = None, **kwargs: Any) -> _F | Callable[[_F], _F]:
@@ -472,6 +483,26 @@ def custom_functions_meta(module, typehinted_params_to_exclude=None):
 
 
 # Custom scripts
+@overload
+def script(f: _F) -> _F:
+    ...
+
+
+@overload
+def script(
+    f: None = ...,
+    name: str | None = ...,
+    required_roles: list[str] | None = ...,
+    include: str | None = ...,
+    exclude: str | None = ...,
+    button: str | None = ...,
+    show_taskpane: bool | None = ...,
+    lazy: bool = ...,
+    **kwargs: Any,
+) -> Callable[[_F], _F]:
+    ...
+
+
 def script(
     f: Callable[..., Any] | None = None,
     name: str | None = None,


### PR DESCRIPTION
This fixes an issue when calling decorated functions in Python, e.g., 

```python
@func
def hello(name: str):
    return f"Hello {name}!!"

def test_example():
    assert hello("x") == "Hello x!"  # flags 'x': Argument is incorrect: Expected `(name: str) -> Unknown`, found `Literal["x"]`
```