### PR TITLE
by default, make load() on BookAsync only load metadata without values

### DIFF
--- a/tests/test_async_load.py
+++ b/tests/test_async_load.py
@@ -1,0 +1,201 @@
+"""
+Tests for the async (lazy) book load semantics in the remote backend:
+
+* an async book is marked lazy (``Book._lazy``); sync ``.value`` reads raise
+  until values are loaded
+* ``Book.load()`` / ``Sheet.load()`` default to metadata-only on a lazy book and
+  to a full (values) load on a regular book; ``values=True`` forces a value load
+* a metadata-only load doesn't clobber values already loaded
+
+``js`` / ``pyodide`` aren't available in the test environment and the load
+methods gate on ``sys.platform == "emscripten"``, so the fixtures below fake just
+enough of that surface to run the real branching logic.
+"""
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+import xlwings as xw
+from xlwings import XlwingsError
+from xlwings.pro import _xlremote as R
+
+
+def _book_json(values=None):
+    return {
+        "client": "Office.js",
+        "version": xw.__version__,
+        "book": {"name": "B", "active_sheet_index": 0, "selection": "A1"},
+        "names": [],
+        "sheets": [
+            {
+                "name": "S",
+                "values": values if values is not None else [[]],
+                "pictures": [],
+                "tables": [],
+            }
+        ],
+    }
+
+
+def _make_book(lazy, values=None):
+    """Create an impl Book through a real *remote* App.
+
+    Building via R.App(...).books.open(...) makes `book.app.engine` the remote
+    engine, so reads go through the remote backend rather than launching the
+    native Excel engine (which xw.App(impl=None) would do if `book.app` were
+    None).
+    """
+    app = R.App(R.Apps(), add_book=False)
+    return app.books.open(_book_json(values), lazy=lazy)
+
+
+# --- raw_value guard (no js needed) ---
+
+
+def test_lazy_book_value_read_raises():
+    book = _make_book(lazy=True)
+    rng = R.Range(sheet=book.sheets.active, arg1=(1, 1))
+    with pytest.raises(XlwingsError, match="haven't been loaded"):
+        rng.raw_value
+
+
+def test_eager_book_value_read_works():
+    book = _make_book(lazy=False, values=[[1, 2], [3, 4]])
+    rng = R.Range(sheet=book.sheets.active, arg1=(1, 1))
+    assert rng.raw_value == [(1,)]
+
+
+def test_lazy_book_value_read_works_after_sheet_marked_loaded():
+    book = _make_book(lazy=True, values=[[1, 2], [3, 4]])
+    sheet = book.sheets.active
+    rng = R.Range(sheet=sheet, arg1=(1, 1))
+    with pytest.raises(XlwingsError):
+        rng.raw_value
+    R._mark_sheet_values_loaded(sheet.api)
+    assert rng.raw_value == [(1,)]
+
+
+def test_loaded_state_survives_sheet_rename():
+    # Regression: loaded state must not be keyed on the mutable sheet name.
+    book = _make_book(lazy=True, values=[[1, 2], [3, 4]])
+    sheet = book.sheets.active
+    R._mark_sheet_values_loaded(sheet.api)
+    rng = R.Range(sheet=sheet, arg1=(1, 1))
+    assert rng.raw_value == [(1,)]
+    sheet.api["name"] = "Renamed"  # rename without emitting a JS action
+    assert rng.raw_value == [(1,)]  # still loaded, must not raise
+
+
+# --- load() branching (js/emscripten faked) ---
+
+
+@pytest.fixture
+def fake_emscripten(monkeypatch):
+    """Fake sys.platform + js/pyodide so load() runs its real branching logic.
+
+    getBookData records the options it was called with and returns book data
+    whose sheet values are non-empty only when NOT lazy (mirroring the server).
+    """
+    monkeypatch.setattr(sys, "platform", "emscripten")
+
+    calls = []
+
+    async def get_book_data(opts=None):
+        opts = dict(opts) if opts else {}
+        calls.append(opts)
+        lazy = opts.get("lazy", False)
+        values = [[]] if lazy else [[10, 20], [30, 40]]
+        return SimpleNamespace(to_py=lambda: _book_json(values))
+
+    js = ModuleType("js")
+    js.xlwings = SimpleNamespace(getBookData=get_book_data)
+    # to_js(..., dict_converter=js.Object.fromEntries) references this; our fake
+    # to_js ignores it, but the attribute must exist to be passed as an arg.
+    js.Object = SimpleNamespace(fromEntries=lambda x: x)
+
+    pyodide = ModuleType("pyodide")
+    ffi = ModuleType("pyodide.ffi")
+    # to_js just needs to pass the plain dict through for our fake getBookData.
+    ffi.to_js = lambda obj, dict_converter=None: obj
+    pyodide.ffi = ffi
+
+    monkeypatch.setitem(sys.modules, "js", js)
+    monkeypatch.setitem(sys.modules, "pyodide", pyodide)
+    monkeypatch.setitem(sys.modules, "pyodide.ffi", ffi)
+    return calls
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_lazy_book_load_defaults_to_metadata_only(fake_emscripten):
+    calls = fake_emscripten
+    book = _make_book(lazy=True)
+    await book.load()
+    # Requested a lazy (metadata-only) fetch, and no sheet is marked as loaded.
+    assert calls[-1].get("lazy") is True
+    assert not R._sheet_values_loaded(book.sheets.active.api)
+    # Sync reads still raise.
+    rng = R.Range(sheet=book.sheets.active, arg1=(1, 1))
+    with pytest.raises(XlwingsError):
+        rng.raw_value
+
+
+@pytest.mark.anyio
+async def test_lazy_book_load_values_true_loads_values(fake_emscripten):
+    calls = fake_emscripten
+    book = _make_book(lazy=True)
+    await book.load(values=True)
+    assert calls[-1].get("lazy") is False
+    assert R._sheet_values_loaded(book.sheets.active.api)
+    rng = R.Range(sheet=book.sheets.active, arg1=(1, 1))
+    assert rng.raw_value == [(10,)]
+
+
+@pytest.mark.anyio
+async def test_eager_book_load_defaults_to_full(fake_emscripten):
+    calls = fake_emscripten
+    book = _make_book(lazy=False)
+    await book.load()
+    assert calls[-1].get("lazy") is False
+    assert R._sheet_values_loaded(book.sheets.active.api)
+
+
+@pytest.mark.anyio
+async def test_metadata_only_load_does_not_clobber_loaded_values(fake_emscripten):
+    book = _make_book(lazy=True)
+    await book.load(values=True)  # values now present
+    rng = R.Range(sheet=book.sheets.active, arg1=(1, 1))
+    assert rng.raw_value == [(10,)]
+    await book.load()  # metadata-only refresh must not wipe values
+    assert rng.raw_value == [(10,)]
+
+
+@pytest.mark.anyio
+async def test_sheet_load_values_true_marks_only_that_sheet(fake_emscripten):
+    book = _make_book(lazy=True)
+    sheet = book.sheets.active
+    await sheet.load(values=True)
+    assert R._sheet_values_loaded(sheet.api)
+
+
+# --- through the public xw.Book / xw.Sheet wrappers ---
+
+
+def test_public_wrapper_lazy_value_read_raises():
+    book = xw.Book(impl=_make_book(lazy=True))
+    with pytest.raises(XlwingsError, match="haven't been loaded"):
+        book.sheets[0]["A1"].value
+
+
+@pytest.mark.anyio
+async def test_public_wrapper_forwards_values_kwarg(fake_emscripten):
+    book = xw.Book(impl=_make_book(lazy=True))
+    await book.load(values=True)
+    # Values are now readable through the public wrapper.
+    assert book.sheets[0]["A1"].value is not None

--- a/tests/test_custom_scripts_call.py
+++ b/tests/test_custom_scripts_call.py
@@ -293,3 +293,35 @@ async def test_book_async_annotated_book_is_injected():
     assert len(actions) == 1
     assert actions[0]["values"] == [["async"]]
     book.close()
+
+
+@pytest.mark.anyio
+async def test_book_async_marks_injected_book_lazy():
+    # A BookAsync annotation must mark the injected book lazy, even though the
+    # caller constructs it eagerly (xw.Book(json=...), as xlwings Lite does).
+    # Sync `.value` reads then raise instead of silently returning None.
+    @script
+    async def my_script(book: xw.BookAsync):
+        book.sheets.active["A1"].value  # sync read on a lazy book -> raises
+
+    book = xw.Book(json=BOOK_JSON)
+    assert book.impl._lazy is False  # eager as constructed
+    mod = _make_module(my_script=my_script)
+    with pytest.raises(XlwingsError, match="haven't been loaded"):
+        await custom_scripts_call(mod, "my_script", typehint_to_value={xw.Book: book})
+    assert book.impl._lazy is True  # annotation flipped it
+    book.close()
+
+
+@pytest.mark.anyio
+async def test_plain_book_annotation_stays_eager():
+    # Without BookAsync, the injected book stays eager and sync reads work.
+    @script
+    async def my_script(book: xw.Book):
+        book.sheets.active["A1"].value  # must not raise
+
+    book = xw.Book(json=BOOK_JSON)
+    mod = _make_module(my_script=my_script)
+    await custom_scripts_call(mod, "my_script", typehint_to_value={xw.Book: book})
+    assert book.impl._lazy is False
+    book.close()

--- a/xlwings/base_classes.py
+++ b/xlwings/base_classes.py
@@ -238,7 +238,7 @@ class Book:
     def to_pdf(self, path, quality):
         raise NotImplementedError()
 
-    async def load(self):
+    async def load(self, values=None):
         raise NotImplementedError("Book.load() is only supported in xlwings Lite")
 
     async def flush(self):
@@ -367,7 +367,7 @@ class Sheet:
     def to_html(self, path):
         raise NotImplementedError()
 
-    async def load(self):
+    async def load(self, values=None):
         raise NotImplementedError("Sheet.load() is only supported in xlwings Lite")
 
 

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -1003,13 +1003,20 @@ class Book:
         )
         await self.flush()
 
-    async def load(self) -> Book:
-        """Loads the book's current data from Excel on demand.
+    async def load(self, values: bool | None = None) -> Book:
+        """(Re)loads the book's data from Excel on demand.
+
+        On an async book (see `xw.BookAsync`), this loads only *metadata*
+        (tables, pictures, names) by default — not cell values — since
+        bulk-loading values would defeat the point of the async API. Pass
+        `values=True` to also snapshot all cell values, after which sync
+        `.value` reads work again. On a regular book, everything including
+        values is loaded regardless.
 
         Requires xlwings Lite.
 
         """
-        await self.impl.load()
+        await self.impl.load(values=values)
         return self
 
     def __eq__(self, other: object) -> bool:
@@ -1512,13 +1519,17 @@ class Sheet:
         self.book.activate()
         return self.impl.activate()
 
-    async def load(self) -> Sheet:
-        """Loads the sheet's current data from Excel on demand.
+    async def load(self, values: bool | None = None) -> Sheet:
+        """(Re)loads the sheet's data from Excel on demand.
+
+        Like `Book.load`, this loads only *metadata* by default on an async book
+        and everything (including values) on a regular book. Pass `values=True`
+        to also load this sheet's cell values.
 
         Requires xlwings Lite.
 
         """
-        await self.impl.load()
+        await self.impl.load(values=values)
         return self
 
     def select(self) -> None:

--- a/xlwings/pro/_xlremote.py
+++ b/xlwings/pro/_xlremote.py
@@ -31,28 +31,42 @@ except ImportError:
 from .. import NoSuchObjectError, XlwingsError, __version__, base_classes, utils
 from ..constants import MAX_COLUMNS, MAX_ROWS
 
+# Private marker set on a sheet's api dict once its cell values have been loaded
+# on an async (lazy) book. Stored on the dict (not keyed by sheet name) so it
+# survives renames; the sheet's api dict is preserved across metadata reloads by
+# _update_api_in_place. Only read locally (never serialized back to JS).
+_SHEET_VALUES_LOADED_KEY = "_xlwings_values_loaded"
+
+
+def _mark_sheet_values_loaded(sheet_api):
+    sheet_api[_SHEET_VALUES_LOADED_KEY] = True
+
+
+def _sheet_values_loaded(sheet_api):
+    return sheet_api.get(_SHEET_VALUES_LOADED_KEY, False)
+
 
 def _normalize_jsnull(obj):
-    """Recursively replace Pyodide's ``JsNull`` sentinel with Python ``None``.
+    """Recursively replace Pyodide's `JsNull` sentinel with Python `None`.
 
-    Pyodide >= 0.28 converts JS ``null`` to ``pyodide.ffi.jsnull`` instead of
-    ``None``. Book data coming back from Office.js via ``.to_py()`` therefore
-    contains ``JsNull`` for empty/absent fields (e.g. ``scope_sheet_index`` on
-    book-scoped names, ``address`` for non-cell selections), which breaks the
-    ``is None`` checks throughout this module. Normalize everything back to
-    ``None`` at the JS boundary so downstream code stays Pyodide-version
+    Pyodide >= 0.28 converts JS `null` to `pyodide.ffi.jsnull` instead of
+    `None`. Book data coming back from Office.js via `.to_py()` therefore
+    contains `JsNull` for empty/absent fields (e.g. `scope_sheet_index` on
+    book-scoped names, `address` for non-cell selections), which breaks the
+    `is None` checks throughout this module. Normalize everything back to
+    `None` at the JS boundary so downstream code stays Pyodide-version
     agnostic.
 
-    The ``values`` arrays (cell data) are skipped here for two reasons. First,
-    *book* data (``getBookData()``) represents empty cells as ``""``, not
-    ``null``, so a book's ``values`` cannot contain ``JsNull``. Second, walking
+    The `values` arrays (cell data) are skipped here for two reasons. First,
+    *book* data (`getBookData()`) represents empty cells as `""`, not
+    `null`, so a book's `values` cannot contain `JsNull`. Second, walking
     them would mean an extra full pass over every cell of an eagerly-loaded book
-    (e.g. ``xw.Book(json=...)`` in xlwings Lite's notebook runner).
+    (e.g. `xw.Book(json=...)` in xlwings Lite's notebook runner).
 
     Note this is *not* true for custom function *arguments*: Excel's custom
-    functions runtime sends empty cells in a range argument as JS ``null`` ->
-    ``JsNull``. Those don't pass through here — UDFs use a separate engine, so
-    they're normalized in ``_xlofficejs._clean_value_data_element`` instead.
+    functions runtime sends empty cells in a range argument as JS `null` ->
+    `JsNull`. Those don't pass through here — UDFs use a separate engine, so
+    they're normalized in `_xlofficejs._clean_value_data_element` instead.
     """
     try:
         from pyodide.ffi import JsNull
@@ -322,13 +336,16 @@ class Books(base_classes.Books):
         )
         # open() normalizes JsNull -> None
         book_data = book_data_js.to_py()
-        return self.open(book_data)
+        # The book was fetched lazily (structure only, no cell values), so mark
+        # it: sync `.value` reads raise until values are loaded, and `load()`
+        # defaults to metadata-only. See Book.load / Range.api.
+        return self.open(book_data, lazy=True)
 
-    def open(self, json):
+    def open(self, json, lazy=False):
         # Normalize here (rather than only at the getBookData boundary) so that
         # callers passing raw `.to_py()` data straight to `xw.Book(json=...)`
         # (e.g. xlwings Lite's notebook runner) also get JsNull -> None.
-        book = Book(api=_normalize_jsnull(json), books=self)
+        book = Book(api=_normalize_jsnull(json), books=self, lazy=lazy)
         self.books.append(book)
         self._active = book
         return book
@@ -375,10 +392,17 @@ class Books(base_classes.Books):
 
 
 class Book(base_classes.Book):
-    def __init__(self, api, books):
+    def __init__(self, api, books, lazy=False):
         self.books = books
         self._api = api
         self._json = {"actions": []}
+        # Async/lazy book: fetched with structure only (no cell values). While
+        # lazy, sync `.value` reads on a sheet whose values haven't been loaded
+        # raise (use `await get_value()` or `await load(values=True)`), and
+        # `load()` defaults to metadata-only. Whether a sheet's values are loaded
+        # is marked per sheet on its api dict (see `_SHEET_VALUES_LOADED_KEY`), so
+        # it survives sheet renames.
+        self._lazy = lazy
         if api["version"] != __version__ and api["client"] != "Office.js":
             raise XlwingsError(
                 f"Your xlwings version is different on the client ({api['version']}) "
@@ -423,14 +447,38 @@ class Book(base_classes.Book):
         # Yield to the browser event loop so it can repaint (to print to output pane)
         await asyncio.sleep(0.01)
 
-    async def load(self):
-        """Fetch values for all sheets from Excel."""
+    async def load(self, values=None):
+        """(Re)load the book's data from Excel on demand.
+
+        On an async (lazy) book, this defaults to loading only *metadata* -
+        sheet structure, tables, pictures, names - and not cell values, since
+        bulk-loading values would defeat the point of the async API. Pass
+        `values=True` to also snapshot all cell values (after which sync
+        `.value` reads work again).
+
+        On a regular (eager) book, everything including values is loaded, as
+        before.
+        """
         if sys.platform != "emscripten":
             raise NotImplementedError("Book.load() is only supported in xlwings Lite")
         import js
+        from pyodide.ffi import to_js
 
-        data = _normalize_jsnull((await js.xlwings.getBookData()).to_py())
+        # Default: metadata-only for lazy books, full for eager books.
+        load_values = (not self._lazy) if values is None else bool(values)
+        # getBookData(lazy=True) returns structure only (empty values); a plain
+        # call returns everything.
+        opts = to_js({"lazy": not load_values}, dict_converter=js.Object.fromEntries)
+        data = _normalize_jsnull((await js.xlwings.getBookData(opts)).to_py())
+        if not load_values:
+            # Metadata-only: don't let the empty `values` payload clobber any
+            # values already loaded on this book.
+            for sheet in data.get("sheets", []):
+                sheet.pop("values", None)
         _update_api_in_place(self._api, data)
+        if load_values:
+            for sheet in self._api.get("sheets", []):
+                _mark_sheet_values_loaded(sheet)
         get_range_api.cache_clear()
 
     @property
@@ -633,21 +681,37 @@ class Sheet(base_classes.Sheet):
     def freeze_panes(self):
         return FreezePanes(self)
 
-    async def load(self):
-        """Fetch values, tables, pictures, and names for this sheet from Excel."""
+    async def load(self, values=None):
+        """(Re)load this sheet's data from Excel on demand.
+
+        Like `Book.load`, this loads only *metadata* (tables, pictures, names,
+        structure) by default on an async (lazy) book, and everything including
+        values on a regular book. Pass `values=True` to also load this sheet's
+        cell values.
+        """
         if sys.platform != "emscripten":
             raise NotImplementedError("Sheet.load() is only supported in xlwings Lite")
         import js
         from pyodide.ffi import to_js
 
-        book_data_js = await js.xlwings.getBookData(
-            to_js({"include": self.name}, dict_converter=js.Object.fromEntries)
+        book = self.book
+        load_values = (not book._lazy) if values is None else bool(values)
+        opts = to_js(
+            {"include": self.name, "lazy": not load_values},
+            dict_converter=js.Object.fromEntries,
         )
+        book_data_js = await js.xlwings.getBookData(opts)
         book_data = _normalize_jsnull(book_data_js.to_py())
         for sheet_data in book_data["sheets"]:
             if sheet_data["name"] == self.name:
+                if not load_values:
+                    # Don't clobber any values already present with the empty
+                    # metadata-only payload.
+                    sheet_data.pop("values", None)
                 self._api.update(sheet_data)
                 break
+        if load_values:
+            _mark_sheet_values_loaded(self._api)
         get_range_api.cache_clear()
 
 
@@ -804,6 +868,17 @@ class Range(base_classes.Range):
 
     @property
     def raw_value(self):
+        # On an async (lazy) book, cell values aren't pre-loaded. Reading `.value`
+        # synchronously would silently return None; raise instead and point to
+        # the async API. `await get_value()` doesn't go through here (it fetches
+        # via getRangeValues), and `await book.load(values=True)` marks the sheet
+        # as loaded, after which sync reads work again.
+        if self.sheet.book._lazy and not _sheet_values_loaded(self.sheet.api):
+            raise XlwingsError(
+                f"Cell values of sheet '{self.sheet.name}' haven't been loaded "
+                "(async book). Use 'await myrange.get_value()' to read on demand, "
+                "or 'await book.load(values=True)' to load all values first."
+            )
         return self.api
 
     @raw_value.setter

--- a/xlwings/pro/udfs_officejs.py
+++ b/xlwings/pro/udfs_officejs.py
@@ -845,10 +845,19 @@ async def custom_scripts_call(
         # BookAsync is a Book subclass and a type hint for the async API; the
         # caller keys the injected book under xw.Book, so normalize before the
         # lookup.
-        if hint is xw.BookAsync:
+        book_is_async = hint is xw.BookAsync
+        if book_is_async:
             hint = xw.Book
         if hint in typehint_to_value:
-            call_args.append(typehint_to_value[hint])
+            injected_book = typehint_to_value[hint]
+            # A BookAsync annotation makes the injected book lazy: no cell values
+            # were pre-loaded, so sync `.value` reads raise until values are
+            # loaded (see Range.raw_value in the remote backend). The book is
+            # constructed by the caller (e.g. xw.Book(json=...) in xlwings Lite),
+            # which can't know the annotation, so we set it here.
+            if book_is_async:
+                injected_book.impl._lazy = True
+            call_args.append(injected_book)
         elif param.kind == inspect.Parameter.VAR_POSITIONAL:
             call_args.extend(arg_iter)
         else:


### PR DESCRIPTION
* Also raises an error if `.value` is accessed on `BookAsync`