### PR TITLE
Improve type inference for RangeRows and RangeColumns indexing

### DIFF
--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -20,7 +20,7 @@ import warnings
 from contextlib import contextmanager
 from os import PathLike
 from pathlib import Path
-from typing import Any, ClassVar, Generator, Generic, Iterator, TypeVar
+from typing import Any, ClassVar, Generator, Generic, Iterator, TypeVar, overload
 
 import xlwings
 
@@ -2951,6 +2951,14 @@ class RangeRows(Ranges):
     def __call__(self, key: int) -> Range:
         return self.rng[key - 1, :]
 
+    @overload
+    def __getitem__(self, key: int) -> Range:
+        ...
+
+    @overload
+    def __getitem__(self, key: slice) -> RangeRows:
+        ...
+
     def __getitem__(self, key: int | slice) -> Range | RangeRows:
         if isinstance(key, slice):
             return RangeRows(rng=self.rng[key, :])
@@ -3012,6 +3020,14 @@ class RangeColumns(Ranges):
 
     def __call__(self, key: int) -> Range:
         return self.rng[:, key - 1]
+
+    @overload
+    def __getitem__(self, key: int) -> Range:
+        ...
+
+    @overload
+    def __getitem__(self, key: slice) -> RangeColumns:
+        ...
 
     def __getitem__(self, key: int | slice) -> Range | RangeColumns:
         if isinstance(key, slice):


### PR DESCRIPTION
## Description

`RangeRows.__getitem__` and `RangeColumns.__getitem__` currently return a union of the possible result types, even though the return type is determined by the type of the key.

This PR adds `typing.overload` definitions to express this relationship to static type checkers.

The resulting type inference is:

- `RangeRows[int]` → `Range`
- `RangeRows[slice]` → `RangeRows`
- `RangeColumns[int]` → `Range`
- `RangeColumns[slice]` → `RangeColumns`

For example:

```python
row = rows[0]            # Range
rows_subset = rows[0:2]  # RangeRows

column = columns[0]            # Range
columns_subset = columns[0:2]  # RangeColumns
```

This only improves static type information and does not change runtime behavior.

## Testing
Verified the inferred types with Pyright;
```python
rows[0]       → Range
rows[0:2]     → RangeRows
columns[0]    → Range
columns[0:2]  → RangeColumns
```
